### PR TITLE
Fix tutor and coach availability queries and role checks

### DIFF
--- a/src/firestore/firestoreFetch.js
+++ b/src/firestore/firestoreFetch.js
@@ -186,15 +186,14 @@ export const firestoreFetchStudentRequests = (setCalendarStudentRequests, calend
 
 export const fetchCacheTutors = () =>
     getCachedOrFetch('tutors', async () => {
-        const roleSnapshot = await getDocs(
-            query(collection(db, 'users'), where('role', 'in', ['tutor', 'coach']))
-        );
-        const rolesListSnapshot = await getDocs(
-            query(collection(db, 'users'), where('rolesList', 'array-contains-any', ['tutor', 'coach']))
-        );
+        const [roleSnapshot, defaultRoleSnapshot, userRolesSnapshot] = await Promise.all([
+            getDocs(query(collection(db, 'users'), where('role', 'in', ['tutor', 'coach']))),
+            getDocs(query(collection(db, 'users'), where('defaultRole', 'in', ['tutor', 'coach']))),
+            getDocs(query(collection(db, 'users'), where('userRoles', 'array-contains-any', ['tutor', 'coach']))),
+        ]);
 
         const usersMap = new Map();
-        [...roleSnapshot.docs, ...rolesListSnapshot.docs].forEach((doc) => {
+        [...roleSnapshot.docs, ...defaultRoleSnapshot.docs, ...userRolesSnapshot.docs].forEach((doc) => {
             const { email, name } = doc.data();
             usersMap.set(email, name);
         });

--- a/src/providers/CalendarUIProvider.jsx
+++ b/src/providers/CalendarUIProvider.jsx
@@ -156,8 +156,8 @@ export const CalendarUIProvider = ({ children }) => {
             );
         }
 
-        // for tutors: split own availabilities around shifts as RBC events (never other tutors')
-        if (userRole === 'tutor' && showTutorInitials && !hideOwnAvailabilities) {
+        // for tutors/coaches: split own availabilities around shifts as RBC events (never other tutors')
+        if ((userRole === 'tutor' || userRole === 'coach') && showTutorInitials && !hideOwnAvailabilities) {
             let availabilities = calendarAvailabilities.filter(a => a.tutor === userEmail);
             if (filterAvailabilityByWorkType) {
                 availabilities = availabilities.filter(a => matchesWorkTypeFilter(a.workType, filterAvailabilityByWorkType.value));
@@ -181,8 +181,8 @@ export const CalendarUIProvider = ({ children }) => {
 
         let filtered = calendarAvailabilities;
 
-        // tutors: hide own availabilities if CalendarUIProvider setting is enabled
-        if (userRole === 'tutor') {
+        // tutors/coaches: hide own availabilities if CalendarUIProvider setting is enabled
+        if (userRole === 'tutor' || userRole === 'coach') {
             if (hideOwnAvailabilities) {
                 filtered = filtered.filter((a) => a.tutor !== userEmail);
             } else {


### PR DESCRIPTION
This pull request updates the handling of tutor and coach roles throughout the codebase to ensure consistency and support for both roles in key logic. The most important changes are grouped below:

Role handling improvements:

* Updated the `fetchCacheTutors` function in `firestoreFetch.js` to include users whose `defaultRole` or `userRoles` fields contain 'tutor' or 'coach', in addition to the existing `role` field. This ensures all tutors and coaches are included in the cached list.

Calendar UI logic updates:

* Modified logic in `CalendarUIProvider.jsx` so that both tutors and coaches (not just tutors) have their own availabilities split around shifts as RBC events, provided the relevant settings are enabled.
* Adjusted the filtering of availabilities in `CalendarUIProvider.jsx` to hide the current user's availabilities for both tutors and coaches, depending on the UI setting, instead of only for tutors.