### PR TITLE
fix: fb and nextauth handshake to call from JWT's token.firebaseToken

### DIFF
--- a/src/lib/security/authConfig.js
+++ b/src/lib/security/authConfig.js
@@ -139,9 +139,9 @@ async function handleJwt({ token, user, account, profile }) {
 
         // signin user after verified in NextAuth signIn callback
         const userUid = user.email.toLowerCase();
-        user.firebaseToken = await adminDbAuth.createCustomToken(userUid, {
-            role: user.role,
-            userRoles: user.userRolesList
+        token.firebaseToken = await adminDbAuth.createCustomToken(userUid, {
+            defaultRole: user.defaultRole || user.role,
+            userRoles: user.userRolesList || [],
         });
 
         // retrieve access / refresh tokens from Azure - store in JWT


### PR DESCRIPTION
- Moved firebaseToken assignment from the user object to the token object in the JWT callback to ensure it persists in the NextAuth session
- Renamed the role claim to defaultRole to align with the request.auth.token.defaultRole check in Firestore security rules