### PR TITLE
fix(#49): remove useEffect that snapped month view back on Next/Prev

### DIFF
--- a/src/components/calendar/CalendarContent.jsx
+++ b/src/components/calendar/CalendarContent.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay, addDays } from 'date-fns';
 import enAU from 'date-fns/locale/en-AU';
@@ -73,11 +73,6 @@ const CalendarContent = () => {
 
     // track the calendar's displayed date to keep it in sync with the data provider
     const [calendarDate, setCalendarDate] = useState(() => calendarDateRange.start);
-
-    // sync calendar date with data provider's date range on mount/navigation
-    useEffect(() => {
-        setCalendarDate(calendarDateRange.start);
-    }, [calendarDateRange.start]);
 
     /* ----------------------------------------------------------- */
     /* Events and Availabilities - Pre-filtered by CalendarUIContextProvider */


### PR DESCRIPTION
## Summary

Closes #49

React Big Calendar's `onRangeChange` returns a range whose `start` date is the **first day shown in the grid** — for a month view that is a few days before the 1st of the displayed month (e.g. April 27 for a May grid). A `useEffect` in `CalendarContent` was watching `calendarDateRange.start` and writing it back into `calendarDate`. This caused the calendar to snap back to the previous month immediately after every Next click.

Removing the `useEffect` is safe because:
- Initial value of `calendarDate` is already seeded from `calendarDateRange.start` via `useState`.
- `handleNavigate` (bound to `onNavigate`) correctly sets `calendarDate` to the navigated-to date.
- `handleCalendarRangeChange` (bound to `onRangeChange`) still updates the Firestore query range independently.

## Files changed

| File | Change |
|---|---|
| `src/components/calendar/CalendarContent.jsx` | Remove 4-line `useEffect` that synced `calendarDate` from range start; remove unused `useEffect` import |

## Test plan

- [x] Open the calendar in **Month** view.
- [x] Click **Next** → calendar advances to the next month and stays there.
- [x] Click **Prev** → calendar goes back correctly.
- [x] Click **Today** → calendar returns to the current month.
- [x] Switch to Week/Day view and verify Prev/Next still work normally.
- [x] Confirm that events for the newly displayed month are fetched from Firestore.

https://claude.ai/code/session_01JEm1d527fNVFVNXaJH6R9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEm1d527fNVFVNXaJH6R9g)_