### PR TITLE
fix(#50): show coach availability events on the RBC calendar

### DIFF
--- a/src/contexts/CalendarUIContext.jsx
+++ b/src/contexts/CalendarUIContext.jsx
@@ -172,8 +172,8 @@ export const CalendarUIContextProvider = ({ children }) => {
             );
         }
 
-        // for tutors: split own availabilities around shifts as RBC events (never other tutors')
-        if (userRole === 'tutor' && showTutorInitials && !hideOwnAvailabilities) {
+        // for tutors/coaches: split own availabilities around shifts as RBC events (never other tutors')
+        if ((userRole === 'tutor' || userRole === 'coach') && showTutorInitials && !hideOwnAvailabilities) {
             let availabilities = calendarAvailabilities.filter(a => a.tutor === userEmail);
             if (filterAvailabilityByWorkType && filterAvailabilityByWorkType.length > 0) {
                 availabilities = availabilities.filter(a =>
@@ -199,8 +199,8 @@ export const CalendarUIContextProvider = ({ children }) => {
 
         let filtered = calendarAvailabilities;
 
-        // tutors: hide own availabilities if CalendarUIContextProvider setting is enabled
-        if (userRole === 'tutor') {
+        // tutors/coaches: hide own availabilities if CalendarUIContextProvider setting is enabled
+        if (userRole === 'tutor' || userRole === 'coach') {
             if (hideOwnAvailabilities) {
                 filtered = filtered.filter((a) => a.tutor !== userEmail);
             } else {


### PR DESCRIPTION
## Summary

Closes #50

`CalendarUIContext` had two `useMemo` blocks that built the filtered event list and the availability overlay, both gated behind `userRole === 'tutor'`. Coaches were excluded from both paths, so their availability records were saved to Firestore but never surfaced as calendar events.

Extending both role checks to `userRole === 'tutor' || userRole === 'coach'` brings coaches into the same display pipeline tutors already use.

## Files changed

| File | Change |
|---|---|
| `src/contexts/CalendarUIContext.jsx` | Two `if` guards extended from `'tutor'` to `'tutor' \|\| 'coach'` |

## Test plan

- [x] Log in as a coach and add a new availability slot → the availability block should appear on the calendar immediately.
- [x] Toggle **Show tutor availability** off → coach's own availability blocks should hide.
- [x] Toggle **Hide own availabilities** on → coach's blocks should disappear.
- [x] Verify that a tutor's calendar is unaffected (availability still displays as before).

https://claude.ai/code/session_01JEm1d527fNVFVNXaJH6R9g

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEm1d527fNVFVNXaJH6R9g)_