### PR TITLE
fix: role list scroll, work-type role validation, availability submit spam

### DIFF
--- a/src/components/calendar/CalendarRenderModals.jsx
+++ b/src/components/calendar/CalendarRenderModals.jsx
@@ -6,7 +6,7 @@ import useAuthSession from '@/hooks/useAuthSession';
 
 const CalendarRenderModals = ({ calendarAction, calendarTarget, updateCalendarTarget, onClose }) => {
     const modalActionStrategy = useModalActionStrategy(calendarAction);
-    const { session, userRole } = useAuthSession();
+    const { session, userRole, userRoles } = useAuthSession();
     const userEmail = session.user.email;
 
     // memoise the modal data so it doesn't recreate on every render
@@ -55,6 +55,7 @@ const CalendarRenderModals = ({ calendarAction, calendarTarget, updateCalendarTa
         setShowStudentModal: onClose,
         userEmail,
         userRole,
+        userRoles,
     };
 
     if (dataProp === 'newEvent') {

--- a/src/components/forms/TutorAvailabilityForm.jsx
+++ b/src/components/forms/TutorAvailabilityForm.jsx
@@ -21,9 +21,13 @@ const TutorAvailabilityForm = ({
     setNewAvailability,
     eventToEdit,
     setShowModal,
+    userRole,
+    userRoles = [],
 }) => {
     const { calendarAvailabilities, setCalendarAvailabilities } = useAppData();
     const { addAlert } = useAlert();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
     // Derive mode flags
     const isView = mode === 'view';
     const isEdit = mode === 'edit';
@@ -40,9 +44,10 @@ const TutorAvailabilityForm = ({
         { value: 'remote', label: 'Remote' },
     ];
 
+    const allRoles = [userRole, ...userRoles].filter(Boolean);
     const workTypeOptions = [
-        { value: 'tutoring', label: 'Tutoring' },
-        { value: 'coaching', label: 'Coaching' },
+        ...(allRoles.includes('tutor') ? [{ value: 'tutoring', label: 'Tutoring' }] : []),
+        ...(allRoles.includes('coach') ? [{ value: 'coaching', label: 'Coaching' }] : []),
         { value: 'work', label: 'Work' },
     ];
 
@@ -122,10 +127,16 @@ const TutorAvailabilityForm = ({
 
     const onSubmit = async (e) => {
         e.preventDefault();
+        if (isSubmitting) return false;
         if (!validateDates()) {
             return false; // Validation failed - don't close modal
         }
-        return await handleSubmit(e); // Pass through the result
+        setIsSubmitting(true);
+        try {
+            return await handleSubmit(e); // Pass through the result
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     const handleLocationChange = (selectedOption) => {
@@ -170,6 +181,7 @@ const TutorAvailabilityForm = ({
             size="lg"
             onSubmit={isView ? undefined : onSubmit}
             submitText={isEdit ? 'Save Changes' : 'Add Availability'}
+            loading={isSubmitting}
             deleteButton={
                 isEdit
                     ? {

--- a/src/styles/userRoles.module.css
+++ b/src/styles/userRoles.module.css
@@ -3,6 +3,9 @@
     background: white;
     border-radius: 0.75rem;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .headerActions {
@@ -19,7 +22,8 @@
 }
 
 .tableContainer {
-    height: calc(100vh - 250px);
+    flex: 1;
+    min-height: 0;
     overflow-y: auto;
     border: 1px solid var(--bs-border-color);
     border-radius: 0.5rem;


### PR DESCRIPTION
Closes #57
Closes #61
Closes #62

## Summary

- **#57 — Role list not scrolling to bottom**: Replaced the hardcoded `height: calc(100vh - 250px)` on `.tableContainer` with `flex: 1; min-height: 0` and made `.managerContainer` a flex column. The table now fills the remaining space dynamically and accounts for parent padding at any viewport size.

- **#61 — No work-type validation based on roles**: `TutorAvailabilityForm` now derives `workTypeOptions` from the user's `defaultRole` plus `userRoles` (additional roles). Tutors see *Tutoring + Work*, coaches see *Coaching + Work*, and users who hold both roles see all three. `userRoles` is threaded from `CalendarRenderModals` via `useAuthSession`.

- **#62 — No safeguard against spamming the Add Availability button**: Added an `isSubmitting` boolean state in `TutorAvailabilityForm`. It is set to `true` before the Firestore write and cleared in a `finally` block, and is forwarded to `BaseModal` as the `loading` prop so the submit button is disabled for the entire duration of the in-flight request.

## Files changed

| File | Change |
|---|---|
| `src/styles/userRoles.module.css` | flex layout on container; table takes remaining height |
| `src/components/forms/TutorAvailabilityForm.jsx` | role-aware work-type options; `isSubmitting` guard |
| `src/components/calendar/CalendarRenderModals.jsx` | thread `userRoles` into modal props |

---
_Generated by [Claude Code](https://claude.ai/code/session_012DbCKmTivqEJrXoa4Z5Rfd)_