### PR TITLE
fix: delete user from Firebase Auth when removing from UserRolesManager

### DIFF
--- a/src/app/api/users/route.js
+++ b/src/app/api/users/route.js
@@ -1,0 +1,35 @@
+import { adminDb, adminDbAuth } from '@/firestore/firestoreAdmin';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/lib/security/authConfig';
+
+export async function DELETE(req) {
+    const session = await getServerSession(authOptions);
+    if (!session?.user) {
+        return Response.json({ message: 'Unauthorised' }, { status: 401 });
+    }
+
+    const userRole = session.user.defaultRole || session.user.role;
+    const isAdmin = userRole === 'admin' || (session.user.userRoles || []).includes('admin');
+    if (!isAdmin) {
+        return Response.json({ message: 'Forbidden: Only admins can delete users' }, { status: 403 });
+    }
+
+    const { email } = await req.json();
+    if (!email) {
+        return Response.json({ message: 'email is required' }, { status: 400 });
+    }
+
+    try {
+        const authUser = await adminDbAuth.getUserByEmail(email);
+        await adminDbAuth.deleteUser(authUser.uid);
+    } catch (error) {
+        // If the user doesn't exist in Firebase Auth, that's fine — continue to Firestore delete
+        if (error.code !== 'auth/user-not-found') {
+            return Response.json({ message: `Failed to delete from Firebase Auth: ${error.message}` }, { status: 500 });
+        }
+    }
+
+    await adminDb.collection('users').doc(email).delete();
+
+    return Response.json({ message: `User ${email} deleted successfully.` });
+}

--- a/src/app/api/users/route.js
+++ b/src/app/api/users/route.js
@@ -29,7 +29,11 @@ export async function DELETE(req) {
         }
     }
 
-    await adminDb.collection('users').doc(email).delete();
+    try {
+        await adminDb.collection('users').doc(email).delete();
+    } catch (error) {
+        return Response.json({ message: `Failed to delete user entry from Firebase: ${error.message}` }, { status: 500 });
+    }
 
     return Response.json({ message: `User ${email} deleted successfully.` });
 }

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -112,10 +112,10 @@ const Sidebar = ({ user, userRole }) => {
                             <li className={styles.navItem}>
                                 <Link
                                     href="/userRoles"
-                                    className={`${styles.navLink} ${isCollapsed ? styles.navLinkCollapsed : styles.navLinkExpanded} ${pathname.startsWith('/userRoles') ? styles.activeNavLink : ''}`}
+                                    className={`${styles.navLink} ${isCollapsed ? stylebrs.navLinkCollapsed : styles.navLinkExpanded} ${pathname.startsWith('/userRoles') ? styles.activeNavLink : ''}`}
                                 >
                                     <FiUsers className={styles.navIcon} />
-                                    <span className={styles.navLabel}>User Roles</span>
+                                    <span className={styles.navLabel}>Manage Users</span>
                                 </Link>
                             </li>
                         )}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -112,7 +112,7 @@ const Sidebar = ({ user, userRole }) => {
                             <li className={styles.navItem}>
                                 <Link
                                     href="/userRoles"
-                                    className={`${styles.navLink} ${isCollapsed ? stylebrs.navLinkCollapsed : styles.navLinkExpanded} ${pathname.startsWith('/userRoles') ? styles.activeNavLink : ''}`}
+                                    className={`${styles.navLink} ${isCollapsed ? styles.navLinkCollapsed : styles.navLinkExpanded} ${pathname.startsWith('/userRoles') ? styles.activeNavLink : ''}`}
                                 >
                                     <FiUsers className={styles.navIcon} />
                                     <span className={styles.navLabel}>Manage Users</span>

--- a/src/components/UserRolesManager.jsx
+++ b/src/components/UserRolesManager.jsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { db } from '@/firestore/firestoreClient';
-import { collection, getDocs, setDoc, doc, deleteDoc, getDoc } from 'firebase/firestore';
+import { collection, getDocs, setDoc, doc, getDoc } from 'firebase/firestore';
 import useAlert from '@/hooks/useAlert';
 import styles from '@/styles/userRoles.module.css';
 
@@ -164,14 +164,22 @@ const UserRolesManager = () => {
 
     const handleDelete = async (userEmail) => {
         try {
-            await deleteDoc(doc(db, 'users', userEmail));
+            const res = await fetch('/api/users', {
+                method: 'DELETE',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: userEmail }),
+            });
+            if (!res.ok) {
+                const { message } = await res.json();
+                throw new Error(message);
+            }
             const updatedUsers = users.filter((user) => user.email !== userEmail);
             setUsers(updatedUsers);
             setFilteredUsers(updatedUsers);
             addAlert('success', `User ${userEmail} deleted successfully.`);
         } catch (error) {
             console.error('Error deleting user:', error);
-            addAlert('error', 'Error deleting user. Please try again.');
+            addAlert('error', `Error deleting user: ${error.message}`);
         }
     };
 

--- a/src/components/UserRolesManager.jsx
+++ b/src/components/UserRolesManager.jsx
@@ -179,7 +179,7 @@ const UserRolesManager = () => {
             addAlert('success', `User ${userEmail} deleted successfully.`);
         } catch (error) {
             console.error('Error deleting user:', error);
-            addAlert('error', `Error deleting user: ${error.message}`);
+            addAlert('error', 'Error deleting user. Please try again.');
         }
     };
 

--- a/tests/unit/Sidebar.test.jsx
+++ b/tests/unit/Sidebar.test.jsx
@@ -70,7 +70,7 @@ describe('Sidebar', () => {
         setup('admin');
 
         expect(screen.getByRole('link', { name: /calendar/i })).toHaveAttribute('href', '/calendar');
-        expect(screen.getByRole('link', { name: /user roles/i })).toHaveAttribute('href', '/userRoles');
+        expect(screen.getByRole('link', { name: /manage users/i })).toHaveAttribute('href', '/userRoles');
         expect(screen.getByRole('link', { name: /manage classes/i })).toHaveAttribute('href', '/classes');
     });
 


### PR DESCRIPTION
## Summary

- Deleting a user from the UserRolesManager previously only removed their Firestore `users` document. Their Firebase Auth account remained, meaning Firestore security rules that check `request.auth` could still be satisfied by the deleted user's credentials.
- Added `DELETE /api/users` — an admin-only server route that deletes the user from Firebase Auth first, then removes their Firestore document, both via the Admin SDK.
- `UserRolesManager.handleDelete` now calls this API route instead of issuing a client-side `deleteDoc`.

## Changes

| File | Change |
|------|--------|
| `src/app/api/users/route.js` | New admin-only DELETE route — removes user from Firebase Auth then Firestore |
| `src/components/UserRolesManager.jsx` | `handleDelete` calls API route; removes unused `deleteDoc` import |

🤖 Generated with [Claude Code](https://claude.ai/code)