### PR TITLE
Prevent event spam: add isSubmitting guard to EventForm and StudentEventForm

### DIFF
--- a/src/components/forms/EventForm.jsx
+++ b/src/components/forms/EventForm.jsx
@@ -277,6 +277,10 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
             addAlert('error', `Failed to submit event: ${error.message}`);
             return false; // Error - don't close modal
         }
+        } catch (error) {
+            console.error('Failed to submit event:', error);
+            addAlert('error', `Failed to submit event: ${error.message}`);
+            return false;
         } finally {
             setIsSubmitting(false);
         }

--- a/src/components/forms/EventForm.jsx
+++ b/src/components/forms/EventForm.jsx
@@ -283,6 +283,7 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
     };
 
     const handleDeleteClick = async () => {
+        if (isSubmitting) return false;
         // Check if this is a recurring event
         const isRecurring = eventToEdit.recurring || eventToEdit.isRecurringInstance;
 
@@ -292,6 +293,7 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
             return false; // Don't close main modal yet - wait for confirmation
         } else {
             // Delete non-recurring event directly
+            setIsSubmitting(true);
             try {
                 await calendarEventHandleDelete(eventToEdit, 'this', {
                     setAllEvents: setCalendarShifts,
@@ -304,11 +306,15 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
                 console.error('Failed to delete event:', error);
                 addAlert('error', 'Failed to delete event');
                 return false; // Error - don't close modal
+            } finally {
+                setIsSubmitting(false);
             }
         }
     };
 
     const handleConfirmDelete = async (deleteOption) => {
+        if (isSubmitting) return;
+        setIsSubmitting(true);
         try {
             await calendarEventHandleDelete(eventToEdit, deleteOption, {
                 setAllEvents: setCalendarShifts,
@@ -323,6 +329,8 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
             addAlert('error', 'Failed to delete event');
             setShowDeleteConfirm(false);
             // Don't close main modal on error
+        } finally {
+            setIsSubmitting(false);
         }
     };
 

--- a/src/components/forms/EventForm.jsx
+++ b/src/components/forms/EventForm.jsx
@@ -48,6 +48,7 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
     const [selectedClasses, setSelectedClasses] = useState(newEvent.classes || []);
     const [selectedStudents, setSelectedStudents] = useState(newEvent.students || []);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const { addAlert } = useAlert();
 
     // fetch form data using custom hook
@@ -138,7 +139,10 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
 
     const onSubmit = async (e) => {
         e.preventDefault();
+        if (isSubmitting) return false;
 
+        setIsSubmitting(true);
+        try {
         // Tutors/coaches may only update workStatus — send only that field to satisfy
         // the Firestore rule: hasOnly(['workStatus']). Skip full form validation: rules
         // like "can't mark a recurring event completed" are admin/teacher concerns and
@@ -273,6 +277,9 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
             addAlert('error', `Failed to submit event: ${error.message}`);
             return false; // Error - don't close modal
         }
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     const handleDeleteClick = async () => {
@@ -376,6 +383,7 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
                 size="lg"
                 onSubmit={(isView && !isTutorPartialEdit) ? undefined : onSubmit}
                 submitText={isTutorPartialEdit ? 'Save Status' : (isEdit ? 'Save Changes' : 'Add Event')}
+                loading={isSubmitting}
                 deleteButton={
                     isEdit
                         ? {

--- a/src/components/forms/StudentEventForm.jsx
+++ b/src/components/forms/StudentEventForm.jsx
@@ -32,6 +32,7 @@ const StudentEventForm = ({
     const isEditing = isEdit || isView; 
     // for backward compat with existing logic
 
+    const [isSubmitting, setIsSubmitting] = useState(false);
     const [tutorOptions, setTutorOptions] = useState([]);
     const [subjectOptions, setSubjectOptions] = useState([]);
     const [filteredTutors, setFilteredTutors] = useState([]);
@@ -239,10 +240,16 @@ const StudentEventForm = ({
 
     const onSubmit = async (e) => {
         e.preventDefault();
+        if (isSubmitting) return false;
         if (!validateDates()) {
             return false; // Validation failed - don't close modal
         }
-        return await handleSubmit(e); // Pass through the result
+        setIsSubmitting(true);
+        try {
+            return await handleSubmit(e);
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
     return (
@@ -253,6 +260,7 @@ const StudentEventForm = ({
             size="md"
             onSubmit={isView ? undefined : onSubmit}
             submitText={isEdit ? 'Save Changes' : 'Add Event'}
+            loading={isSubmitting}
             deleteButton={
                 isEdit
                     ? {

--- a/src/components/forms/StudentEventForm.jsx
+++ b/src/components/forms/StudentEventForm.jsx
@@ -247,6 +247,10 @@ const StudentEventForm = ({
         setIsSubmitting(true);
         try {
             return await handleSubmit(e);
+        } catch (error) {
+            console.error('Failed to submit student event request:', error);
+            addAlert('error', 'Failed to submit event request');
+            return false;
         } finally {
             setIsSubmitting(false);
         }


### PR DESCRIPTION
## Summary

Closes #70

- Add `isSubmitting` state guard to `EventForm` (admin) to prevent duplicate event creates/updates/email notifications when the submit button is clicked multiple times before the first Firestore write resolves
- Add the same guard to `StudentEventForm` (student) to prevent duplicate tutoring session requests
- Pass `loading={isSubmitting}` to `BaseModal` in both forms so the submit and delete buttons are visually disabled and show "Loading…" during in-flight requests

This mirrors the pattern already in place in `TutorAvailabilityForm`.

## Test plan

- [x] Open the admin event form, fill in required fields, and rapidly double-click "Add Event" — only one event should be created in Firestore
- [x] Open the admin event form in edit mode and rapidly double-click "Save Changes" — only one update write should fire
- [x] Open the student event form and rapidly double-click "Add Event" — only one student request should appear
- [x] Confirm the submit button shows "Loading…" and is disabled while the request is in progress in both forms
- [x] Confirm normal single-click submission still works end-to-end for both forms
- [x] Confirm `TutorAvailabilityForm` behaviour is unchanged

https://claude.ai/code/session_01K4VT8gzNadBEHLbbvydyvg

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4VT8gzNadBEHLbbvydyvg)_