### PR TITLE
fix(#74): run isTutorPartialEdit before validateForm so tutors/coaches can save work status

### DIFF
--- a/src/components/forms/EventForm.jsx
+++ b/src/components/forms/EventForm.jsx
@@ -138,11 +138,11 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
 
     const onSubmit = async (e) => {
         e.preventDefault();
-        if (!validateForm()) return false; // Validation failed - don't close modal
 
         // Tutors/coaches may only update workStatus — send only that field to satisfy
-        // the Firestore rule: hasOnly(['workStatus']). Sending a full eventData payload
-        // (which includes emailsList and date fields) would cause the diff check to fail.
+        // the Firestore rule: hasOnly(['workStatus']). Skip full form validation: rules
+        // like "can't mark a recurring event completed" are admin/teacher concerns and
+        // must not gate the tutor/coach single-field write path.
         if (isTutorPartialEdit) {
             try {
                 await updateWorkStatusInFirestore(eventToEdit.id, newEvent.workStatus || 'notCompleted');
@@ -153,6 +153,8 @@ const EventForm = ({ mode, newEvent, setNewEvent, eventToEdit, setShowModal, use
                 return false;
             }
         }
+
+        if (!validateForm()) return false; // Validation failed - don't close modal
 
         // Debug: Check if recurring instance flag is preserved
         console.log('EventForm onSubmit - eventToEdit:', {


### PR DESCRIPTION
## Summary

Closes #74

Tutors and coaches were blocked from saving work status on **recurring** shifts because `validateForm()` ran unconditionally before the `isTutorPartialEdit` early-return, causing the "cannot mark a recurring event completed" rule to fire — a rule intended only for admins/teachers who can actually modify recurrence settings.

## Root cause

```js
// Before — validateForm always ran first
const onSubmit = async (e) => {
    e.preventDefault();
    if (!validateForm()) return false;  // ← blocked tutors on recurring shifts

    if (isTutorPartialEdit) {           // ← never reached
        await updateWorkStatusInFirestore(...)
        return true;
    }
};
```

## Fix

Move `isTutorPartialEdit` above `validateForm()`. Tutors/coaches write only `workStatus` via a targeted Firestore helper, so full form validation is irrelevant to their code path.

```js
// After
const onSubmit = async (e) => {
    e.preventDefault();

    if (isTutorPartialEdit) {           // ← checked first, bypasses validation
        await updateWorkStatusInFirestore(...)
        return true;
    }

    if (!validateForm()) return false;  // ← only runs for admin/teacher path
};
```

## What this also covers

- Prevents the production staff-presence check (`staff.length === 0`) from incorrectly blocking tutors/coaches whose view-mode form may not have staff fully hydrated.
- No change to admin/teacher behaviour — `validateForm()` still runs normally for all other roles.

## Test plan

- [x] Tutor opens a **non-recurring** shift → changes status to Completed → Save Status → succeeds
- [x] Tutor opens a **recurring** shift → changes status to Completed → Save Status → succeeds (previously blocked)
- [x] Coach repeats both cases above
- [x] Admin/teacher edits a recurring completed event → validation still fires as expected
- [x] Admin/teacher submits an event with missing title → validation still fires

https://claude.ai/code/session_01TVQGESLytE43dzHWRLu1pn

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVQGESLytE43dzHWRLu1pn)_