### PR TITLE
fix: firebase custom token expiry causing persistent auth failures

### DIFF
--- a/src/lib/security/authConfig.js
+++ b/src/lib/security/authConfig.js
@@ -137,19 +137,23 @@ async function handleJwt({ token, user, account, profile }) {
         if (user.image) {
             token.picture = user.image;
         }
-
-        const userUid = user.email.toLowerCase();
-
-        token.firebaseToken = await adminDbAuth.createCustomToken(userUid, {
-            defaultRole: user.defaultRole || user.role,
-            userRoles: user.userRolesList || [],
-        });
     }
 
     if (account?.provider === 'azure-ad') {
         token.msAccessToken = account.access_token;
         token.msRefreshToken = account.refresh_token;
         token.msAccessTokenExpiry = account.expires_at * 1000;
+    }
+
+    // regenerate custom token (after 1hr expiry). runs on sign-in and every explicit updateSession() from AuthContext
+    const firebaseUid = token.email.toLowerCase();
+    try {
+        token.firebaseToken = await adminDbAuth.createCustomToken(firebaseUid, {
+            defaultRole: token.defaultRole,
+            userRoles: token.userRoles || [],
+        });
+    } catch (error) {
+        console.error('Failed to create Firebase custom token:', error);
     }
 
     return token;

--- a/src/lib/security/clientAuth.js
+++ b/src/lib/security/clientAuth.js
@@ -61,9 +61,13 @@ export const fbAuthLoginSync = async (token) => {
         return;
     }
 
+    // if Firebase already has a live session fetch - groken ID token from browser. else, re-authenticate. 
     try {
-        await signInWithCustomToken(clientAuth, token);
-        await clientAuth.currentUser?.getIdToken(true);
+        if (clientAuth.currentUser) {
+            await clientAuth.currentUser.getIdToken(true);
+        } else {
+            await signInWithCustomToken(clientAuth, token);
+        }
     } catch (error) {
         console.error("Firebase Sync Error:", error);
     }


### PR DESCRIPTION
## Summary
- `handleJwt` was only generating a Firebase custom token on initial sign-in. Since custom tokens expire after 1 hour but NextAuth sessions persist for days, the cached token would go stale — causing `auth/invalid-custom-token` and cascading Firestore permission failures on subsequent loads
- Moved `createCustomToken` outside the `if (user)` block so it regenerates on every JWT write, meaning the existing 50-min `updateSession()` loop in `AuthContext` now actually produces a fresh token instead of silently re-saving the expired one
- `fbAuthLoginSync` now checks `clientAuth.currentUser` first — if Firebase already has a live session it just force-refreshes the ID token rather than re-authenticating with the custom token (which is the fragile path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)