### PR TITLE
fix: TutorHoursSummary role-switching not updating view

### DIFF
--- a/src/app/tutorHours/page.jsx
+++ b/src/app/tutorHours/page.jsx
@@ -1,16 +1,9 @@
 import TutorHoursSummary from "@/components/TutorHoursSummary";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/security/authConfig";
 
-const TutorHoursPage = async () => {
-    const session = await getServerSession(authOptions);
+const TutorHoursPage = () => {
     return (
         <div className="overflow-y-auto overflow-x-hidden h-100">
-            <TutorHoursSummary
-                userRole={session.user.defaultRole || session.user.role}
-                userRoles={session.user.userRoles}
-                userEmail={session.user.email}
-            />
+            <TutorHoursSummary />
         </div>
     );
 };

--- a/src/components/TutorHoursSummary.jsx
+++ b/src/components/TutorHoursSummary.jsx
@@ -8,6 +8,7 @@ import 'react-datepicker/dist/react-datepicker.css';
 import { CSVLink } from 'react-csv';
 import { FaInfoCircle } from '@/components/icons';
 import useAlert from '@/hooks/useAlert';
+import useAuthSession from '@/hooks/useAuthSession';
 import { recurringCalendarExpand } from '@/utils/calendarRecurringEvents';
 
 const getMonday = (d) => {
@@ -49,9 +50,12 @@ const isTutorConfirmed = (event, tutorEmail) => {
 /**
  * Component to display and manage tutor hours summary
  */
-const TutorHoursSummary = ({ userRole, userRoles, userEmail }) => {
+const TutorHoursSummary = () => {
     const { addAlert } = useAlert();
-    const isAdmin = userRole === 'admin' || userRoles.includes('admin');
+    const { userRole, userRoles, session } = useAuthSession();
+    const userEmail = session?.user?.email;
+    const isAdmin = userRole === 'admin';
+    
     const [startDate, setStartDate] = useState(getMonday(new Date()));
     const [endDate, setEndDate] = useState(() => {
         const monday = getMonday(new Date());
@@ -63,12 +67,11 @@ const TutorHoursSummary = ({ userRole, userRoles, userEmail }) => {
     const [tutorHours, setTutorHours] = useState([]);
 
     const fetchTutorHours = useCallback(async () => {
-        const isTutorOrCoach = userRole === 'tutor' || userRole === 'coach';
         let accessFilter = [];
 
         // Tutors/Coaches: only see their own shifts
         // Admins: see all shifts (no filter)
-        if (isTutorOrCoach) {
+        if (!isAdmin) {
             accessFilter = [where('emailsList', 'array-contains', userEmail)];
         }
 
@@ -166,7 +169,7 @@ const TutorHoursSummary = ({ userRole, userRoles, userEmail }) => {
         }));
 
         // Tutors only see their own summary, admins see everyone
-        if (userRole === 'tutor') {
+        if (!isAdmin) {
             tutorHoursArray = tutorHoursArray.filter((tutor) => tutor.email === userEmail);
         }
 


### PR DESCRIPTION
## Summary

- `TutorHoursPage` was a server component passing `userRole` from `getServerSession` as a static prop — client-side role switching via `AuthContext.switchRole` had no effect on the component
- `TutorHoursSummary` now reads `userRole` and `userEmail` directly from `AuthContext` (`useAuthSession`) so it reactively updates when the user switches views
- `isAdmin` now gates solely on `userRole === 'admin'` (the active role), not `userRoles.includes('admin')` (the full role list), so switching to tutor view correctly restricts the Firestore query and output

