### PR TITLE
fix: tutor availabilities not showing for students

### DIFF
--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -29,6 +29,10 @@ const ClassList = () => {
     const [selectedSubject, setSelectedSubject] = useState(null);
     const [selectedTeacher, setSelectedTeacher] = useState(null);
     const [isEditing, setIsEditing] = useState(false);
+<<<<<<< HEAD
+=======
+    const { addAlert } = useAlert();
+>>>>>>> 7ee86ce (feat: filter by student's enrolled classSubject by default, then render depending on subject choice)
     const [studentsToAdd, setStudentsToAdd] = useState('');
     const [selectedClass, setSelectedClass] = useState(null);
     const [filteredClasses, setFilteredClasses] = useState([]);
@@ -86,46 +90,52 @@ const ClassList = () => {
         e.preventDefault();
         if (!selectedSubject) {
             addAlert('error', 'Please select a subject.');
-            return;
+            return false;
         }
         if (!selectedTeacher) {
             addAlert('error', 'Please select a teacher.');
-            return;
+            return false;
         }
 
-        if (isEditing) {
-            const classRef = doc(db, 'classes', selectedClass.id);
-            await updateDoc(classRef, {
-                name: className,
-                subject: selectedSubject.id,
-                teacherEmail: selectedTeacher.email,
-            });
-            setClasses(
-                classes.map((cls) =>
-                    cls.id === selectedClass.id
-                        ? {
-                              ...cls,
-                              name: className,
-                              subject: selectedSubject.id,
-                              teacherEmail: selectedTeacher.email,
-                          }
-                        : cls,
-                ),
-            );
-            setIsEditing(false);
-        } else {
-            await addDoc(collection(db, 'classes'), {
-                name: className,
-                subject: selectedSubject.id,
-                teacherEmail: selectedTeacher.email,
-            });
+        try {
+            if (isEditing) {
+                const classRef = doc(db, 'classes', selectedClass.id);
+                await updateDoc(classRef, {
+                    name: className,
+                    subject: selectedSubject.id,
+                    teacherEmail: selectedTeacher.email,
+                });
+                setClasses(
+                    classes.map((cls) =>
+                        cls.id === selectedClass.id
+                            ? {
+                                  ...cls,
+                                  name: className,
+                                  subject: selectedSubject.id,
+                                  teacherEmail: selectedTeacher.email,
+                              }
+                            : cls,
+                    ),
+                );
+                setIsEditing(false);
+            } else {
+                await addDoc(collection(db, 'classes'), {
+                    name: className,
+                    subject: selectedSubject.id,
+                    teacherEmail: selectedTeacher.email,
+                });
+            }
+            setClassName('');
+            setSelectedSubject(null);
+            setSelectedTeacher(null);
+            setShowModal(false);
+            addAlert('success', isEditing ? 'Class edited successfully' : 'Class added successfully');
+            fetchClasses();
+        } catch (err) {
+            console.error('Failed to save class:', err);
+            addAlert('error', 'Failed to save class. Please try again.');
+            return false;
         }
-        setClassName('');
-        setSelectedSubject(null);
-        setSelectedTeacher(null);
-        setShowModal(false);
-        addAlert('success', isEditing ? 'Class edited successfully' : 'Class added successfully');
-        fetchClasses();
     };
 
     const handleEditClass = (cls) => {

--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -29,10 +29,6 @@ const ClassList = () => {
     const [selectedSubject, setSelectedSubject] = useState(null);
     const [selectedTeacher, setSelectedTeacher] = useState(null);
     const [isEditing, setIsEditing] = useState(false);
-<<<<<<< HEAD
-=======
-    const { addAlert } = useAlert();
->>>>>>> 7ee86ce (feat: filter by student's enrolled classSubject by default, then render depending on subject choice)
     const [studentsToAdd, setStudentsToAdd] = useState('');
     const [selectedClass, setSelectedClass] = useState(null);
     const [filteredClasses, setFilteredClasses] = useState([]);

--- a/src/components/calendar/CalendarFilterPanel.jsx
+++ b/src/components/calendar/CalendarFilterPanel.jsx
@@ -8,39 +8,54 @@ import { useAppData } from '@/contexts/AppDataContext';
 import CalendarHowToModal from '@/components/modals/CalendarHowToModal';
 import CalendarLegend from './CalendarLegend.jsx';
 import useAuthSession from '@/hooks/useAuthSession';
+import { getEnrolledSubjectIds } from '@/utils/calendarAvailability';
 
 const CalendarFilterPanel = () => {
-    const { userRole } = useAuthSession();
-    const { tutors, subjects } = useAppData();
+    const { session, userRole } = useAuthSession();
+    const userEmail = session.user.email;
+    const { tutors, subjects, classes } = useAppData();
     const { filters, visibility, actions, calendarFilters, calendarScope } = useCalendarUI();
     const [isOpen, setIsOpen] = useState(true);
     const [showHowToModal, setShowHowToModal] = useState(false);
 
-    // Memoise subject options transformation
-    const subjectOptions = useMemo(() =>
-        
-        subjects?.map((subject) => ({
+    const enrolledSubjectIds = useMemo(() =>
+        userRole === 'student' ? getEnrolledSubjectIds(classes, userEmail) : new Set(),
+        [userRole, classes, userEmail]
+    );
+
+    const subjectOptions = useMemo(() => {
+        const options = (subjects ?? []).map(subject => ({
             value: subject.id,
             label: subject.name,
             tutors: subject.tutors,
-        })) || [],
-        [subjects]
-    );
+        }));
+        if (userRole !== 'student' || enrolledSubjectIds.size === 0) return options;
+        return options.filter(subject => enrolledSubjectIds.has(subject.value));
+    }, [subjects, userRole, enrolledSubjectIds]);
 
-    // Memoise tutor options transformation
     const tutorOptions = useMemo(() => {
-        if (userRole === 'student' && filters.filterBySubject) {
-            const selectedSubject = subjects?.find(s => s.id === filters.filterBySubject.value);
-            return selectedSubject?.tutors?.map((tutor) => ({
-                value: tutor.email,
-                label: tutor.name || tutor.email,
-            })) || [];
-        }
-        return tutors?.map((tutor) => ({
+        const mapTutorToOption = (tutor) => ({
             value: tutor.email,
             label: tutor.name || tutor.email,
-        })) || [];
-    }, [userRole, filters.filterBySubject, subjects, tutors]);
+        });
+
+        if (userRole === 'student') {
+            if (filters.filterBySubject) {
+                const selectedSubject = (subjects ?? []).find(s => s.id === filters.filterBySubject.value);
+                return selectedSubject?.tutors?.map(mapTutorToOption) ?? [];
+            }
+            const tutorMap = new Map();
+            for (const subject of (subjects ?? [])) {
+                if (!enrolledSubjectIds.has(subject.id)) continue;
+                for (const tutor of subject.tutors || []) {
+                    tutorMap.set(tutor.email, tutor.name || tutor.email);
+                }
+            }
+            return [...tutorMap].map(([email, name]) => ({ value: email, label: name }));
+        }
+
+        return (tutors ?? []).map(mapTutorToOption);
+    }, [userRole, filters.filterBySubject, subjects, tutors, enrolledSubjectIds]);
 
     // prepare work type options for availabilities
     const availabilityWorkTypeOptions = [
@@ -121,7 +136,7 @@ const CalendarFilterPanel = () => {
                                 options={tutorOptions}
                                 value={filters.filterByTutor}
                                 onChange={actions.setFilterByTutor}
-                                isDisabled={userRole === 'student' && !filters.filterBySubject}
+                                isDisabled={userRole === 'student' && tutorOptions.length === 0}
                             />
                         </div>
                     )}

--- a/src/components/forms/TutorAvailabilityForm.jsx
+++ b/src/components/forms/TutorAvailabilityForm.jsx
@@ -13,6 +13,7 @@ import {
     deleteEventFromFirestore,
 } from '@/firestore/firestoreOperations';
 import { CalendarEntityType } from '@lib/patterns/calendarStrategy';
+import { normaliseWorkType } from '@/utils/calendarAvailability';
 import useAlert from '@/hooks/useAlert';
 
 const TutorAvailabilityForm = ({
@@ -146,14 +147,6 @@ const TutorAvailabilityForm = ({
     const handleWorkTypeChange = (selectedOptions) => {
         const values = selectedOptions ? selectedOptions.map(o => o.value) : [];
         setNewAvailability({ ...newAvailability, workType: values });
-    };
-
-    const normaliseWorkType = (workType) => {
-        if (typeof workType === 'string') {
-            if (workType === 'tutoringOrWork') return ['tutoring', 'work'];
-            return [workType];
-        }
-        return workType;
     };
 
     const getWorkTypeBadge = () => {

--- a/src/contexts/CalendarUIContext.jsx
+++ b/src/contexts/CalendarUIContext.jsx
@@ -5,7 +5,7 @@ import useCalendarStrategy from "@/hooks/useCalendarStrategy"
 import useAuthSession from "@/hooks/useAuthSession"
 import { useAppData } from "@/contexts/AppDataContext"
 import { CalendarEntityType } from "@lib/patterns/calendarStrategy"
-import { calendarAvailabilitySplit, normaliseWorkType } from "@/utils/calendarAvailability"
+import { calendarAvailabilitySplit, normaliseWorkType, getEnrolledSubjectIds, getEnrolledTutorEmails } from "@/utils/calendarAvailability"
 
 /**
  * Returns true if an availability's workType matches the selected filter.
@@ -14,13 +14,13 @@ import { calendarAvailabilitySplit, normaliseWorkType } from "@/utils/calendarAv
 const matchesWorkTypeFilter = (availWorkType, filterWorkType) => {
     const types = normaliseWorkType(availWorkType);
     if (filterWorkType === 'tutoringOrWork') {
-        return types.includes('tutoring') || types.includes('work') || types.includes('tutoringOrWork');
+        return types.includes('tutoring') || types.includes('work');
     }
     if (filterWorkType === 'tutoring') {
-        return types.includes('tutoring') || types.includes('tutoringOrWork');
+        return types.includes('tutoring');
     }
     if (filterWorkType === 'work') {
-        return types.includes('work') || types.includes('tutoringOrWork');
+        return types.includes('work');
     }
     return types.includes(filterWorkType);
 };
@@ -48,7 +48,7 @@ export const CalendarUIContextProvider = ({ children }) => {
     const userEmail = session.user.email;
 
     // Get calendar data
-    const { calendarShifts, calendarAvailabilities, calendarStudentRequests, subjects } = useAppData();
+    const { calendarShifts, calendarAvailabilities, calendarStudentRequests, subjects, classes } = useAppData();
 
     // cal strategy for filters and scope
     const calendarStrategy = useCalendarStrategy(userEmail, userRole);
@@ -209,21 +209,28 @@ export const CalendarUIContextProvider = ({ children }) => {
             }
         }
 
-        // students: filter by selected subject's tutors from CalendarUIContextProvider
-        if (userRole === 'student' && filterBySubject) {
-            const selectedSubject = subjects?.find(s => s.id === filterBySubject.value);
-            if (selectedSubject?.tutors) {
-                const subjectTutorEmails = selectedSubject.tutors.map(t => t.email);
-                filtered = filtered.filter(a => subjectTutorEmails.includes(a.tutor));
-            }
-        }
-
-        // students: only show tutoring availabilities (exclude coaching and work)
+        // students: restrict to tutoring availabilities and relevant tutors
         if (userRole === 'student') {
+            // tutoring workType only
             filtered = filtered.filter(a => {
                 const types = normaliseWorkType(a.workType);
-                return types.length === 0 || types.includes('tutoring') || types.includes('tutoringOrWork');
+                return types.length === 0 || types.includes('tutoring');
             });
+
+            // manual subject filter takes precedence; otherwise auto-scope to enrolled classes
+            if (filterBySubject) {
+                const selectedSubject = subjects?.find(s => s.id === filterBySubject.value);
+                if (selectedSubject?.tutors) {
+                    const allowed = new Set(selectedSubject.tutors.map(t => t.email));
+                    filtered = filtered.filter(a => allowed.has(a.tutor));
+                }
+            } else {
+                const enrolledSubjectIds = getEnrolledSubjectIds(classes, userEmail);
+                const enrolledTutorEmails = getEnrolledTutorEmails(subjects, enrolledSubjectIds);
+                if (enrolledTutorEmails.size > 0) {
+                    filtered = filtered.filter(a => enrolledTutorEmails.has(a.tutor));
+                }
+            }
         }
 
         // filter by selected tutors from CalendarUIContextProvider
@@ -243,7 +250,7 @@ export const CalendarUIContextProvider = ({ children }) => {
         const splitAvailabilities = calendarAvailabilitySplit(filtered, calendarShifts);
 
         return splitAvailabilities;
-    }, [showTutorInitials, calendarAvailabilities, userRole, hideOwnAvailabilities, userEmail, filterBySubject, subjects, filterByTutor, filterAvailabilityByWorkType, calendarShifts]);
+    }, [showTutorInitials, calendarAvailabilities, userRole, hideOwnAvailabilities, userEmail, filterBySubject, subjects, classes, filterByTutor, filterAvailabilityByWorkType, calendarShifts]);
 
     // ─────────────────────────────────────
     // context values

--- a/src/contexts/CalendarUIContext.jsx
+++ b/src/contexts/CalendarUIContext.jsx
@@ -5,24 +5,24 @@ import useCalendarStrategy from "@/hooks/useCalendarStrategy"
 import useAuthSession from "@/hooks/useAuthSession"
 import { useAppData } from "@/contexts/AppDataContext"
 import { CalendarEntityType } from "@lib/patterns/calendarStrategy"
-import { calendarAvailabilitySplit } from "@/utils/calendarAvailability"
+import { calendarAvailabilitySplit, normaliseWorkType } from "@/utils/calendarAvailability"
 
 /**
  * Returns true if an availability's workType matches the selected filter.
- * 'tutoringOrWork' availabilities are included when filtering by 'tutoring' or 'work',
- * and vice-versa.
+ * Handles both the legacy string format and the current array format.
  */
 const matchesWorkTypeFilter = (availWorkType, filterWorkType) => {
+    const types = normaliseWorkType(availWorkType);
     if (filterWorkType === 'tutoringOrWork') {
-        return availWorkType === 'tutoring' || availWorkType === 'work' || availWorkType === 'tutoringOrWork';
+        return types.includes('tutoring') || types.includes('work') || types.includes('tutoringOrWork');
     }
     if (filterWorkType === 'tutoring') {
-        return availWorkType === 'tutoring' || availWorkType === 'tutoringOrWork';
+        return types.includes('tutoring') || types.includes('tutoringOrWork');
     }
     if (filterWorkType === 'work') {
-        return availWorkType === 'work' || availWorkType === 'tutoringOrWork';
+        return types.includes('work') || types.includes('tutoringOrWork');
     }
-    return availWorkType === filterWorkType;
+    return types.includes(filterWorkType);
 };
 
 /**
@@ -220,11 +220,10 @@ export const CalendarUIContextProvider = ({ children }) => {
 
         // students: only show tutoring availabilities (exclude coaching and work)
         if (userRole === 'student') {
-            filtered = filtered.filter(a =>
-                a.workType === 'tutoring' ||
-                a.workType === 'tutoringOrWork' ||
-                a.workType === undefined
-            );
+            filtered = filtered.filter(a => {
+                const types = normaliseWorkType(a.workType);
+                return types.length === 0 || types.includes('tutoring') || types.includes('tutoringOrWork');
+            });
         }
 
         // filter by selected tutors from CalendarUIContextProvider

--- a/src/utils/calendarAvailability.js
+++ b/src/utils/calendarAvailability.js
@@ -1,6 +1,17 @@
 // import { isBefore, isAfter } from 'date-fns';
 
 /**
+ * Normalise workType to an array, handling both the legacy string format
+ * ('tutoring', 'tutoringOrWork', …) and the current array format (['tutoring', 'work']).
+ */
+export const normaliseWorkType = (workType) => {
+    if (!workType) return [];
+    if (Array.isArray(workType)) return workType;
+    if (workType === 'tutoringOrWork') return ['tutoring', 'work'];
+    return [workType];
+};
+
+/**
  * Split availabilities around booked events
  */
 export const calendarAvailabilitySplit = (availabilities, events) => {

--- a/src/utils/calendarAvailability.js
+++ b/src/utils/calendarAvailability.js
@@ -12,6 +12,27 @@ export const normaliseWorkType = (workType) => {
 };
 
 /**
+ * Returns the Set of subject IDs covered by a student's enrolled classes.
+ */
+export const getEnrolledSubjectIds = (classes, userEmail) =>
+    new Set(
+        classes
+            .filter(cls => cls.students?.some(s => s.email === userEmail))
+            .map(cls => cls.subject)
+            .filter(Boolean)
+    );
+
+/**
+ * Returns the Set of tutor emails across a given set of subject IDs.
+ */
+export const getEnrolledTutorEmails = (subjects, enrolledSubjectIds) =>
+    new Set(
+        subjects
+            .filter(s => enrolledSubjectIds.has(s.id))
+            .flatMap(s => (s.tutors || []).map(t => t.email))
+    );
+
+/**
  * Split availabilities around booked events
  */
 export const calendarAvailabilitySplit = (availabilities, events) => {


### PR DESCRIPTION
## Summary
- `workType` was stored as an array in Firestore (e.g. `['tutoring']`) but `CalendarUIContext` compared it as a string, so the student availability filter always evaluated to `false` and returned empty results
- Extracted `normaliseWorkType` from `TutorAvailabilityForm` into `calendarAvailability` utils so it can be shared across the codebase
- Updated `matchesWorkTypeFilter` and the student `workType` filter in `CalendarUIContext` to use `normaliseWorkType`, fixing the type mismatch
- Student calendar now auto-scopes availability overlay to tutors from their enrolled classes — no manual subject selection required for the default view
- Subject dropdown for students is now filtered to only their enrolled subjects
- Tutor dropdown for students now populates from all enrolled subjects when no subject is selected (previously required a subject to be chosen first)
- `ClassList` validation errors now fire through `useAlert` instead of misusing the success state — modal stays open on validation failure and errors appear in the correct alert UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)