### PR TITLE
Replace legacy inline messages with addAlert toast notifications

### DIFF
--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -15,8 +15,10 @@ import {
 import ClassRow from './ClassRow.jsx';
 import ClassModal from './modals/ClassModal.jsx';
 import AddStudentsModal from './modals/AddStudentsModal.jsx';
+import useAlert from '@/hooks/useAlert';
 
 const ClassList = () => {
+    const { addAlert } = useAlert();
     const [classes, setClasses] = useState([]);
     const [subjects, setSubjects] = useState([]);
     const [teachers, setTeachers] = useState([]);
@@ -27,7 +29,6 @@ const ClassList = () => {
     const [selectedSubject, setSelectedSubject] = useState(null);
     const [selectedTeacher, setSelectedTeacher] = useState(null);
     const [isEditing, setIsEditing] = useState(false);
-    const [success, setSuccess] = useState('');
     const [studentsToAdd, setStudentsToAdd] = useState('');
     const [selectedClass, setSelectedClass] = useState(null);
     const [filteredClasses, setFilteredClasses] = useState([]);
@@ -84,11 +85,11 @@ const ClassList = () => {
     const handleAddClass = async (e) => {
         e.preventDefault();
         if (!selectedSubject) {
-            setSuccess('Please select a subject.');
+            addAlert('error', 'Please select a subject.');
             return;
         }
         if (!selectedTeacher) {
-            setSuccess('Please select a teacher.');
+            addAlert('error', 'Please select a teacher.');
             return;
         }
 
@@ -123,7 +124,7 @@ const ClassList = () => {
         setSelectedSubject(null);
         setSelectedTeacher(null);
         setShowModal(false);
-        setSuccess(isEditing ? 'Class edited successfully' : 'Class added successfully');
+        addAlert('success', isEditing ? 'Class edited successfully' : 'Class added successfully');
         fetchClasses();
     };
 
@@ -140,7 +141,7 @@ const ClassList = () => {
         if (classToDelete) {
             await deleteDoc(doc(db, 'classes', classToDelete.id));
             setClasses(classes.filter((cls) => cls.id !== classToDelete.id));
-            setSuccess('Class deleted successfully');
+            addAlert('success', 'Class deleted successfully');
         }
     };
 
@@ -177,7 +178,7 @@ const ClassList = () => {
         setSelectedClass((prev) => ({ ...prev, students: updatedStudents }));
         setStudentsToAdd('');
         setShowStudentModal(false);
-        setSuccess('Students added successfully');
+        addAlert('success', 'Students added successfully');
         fetchClasses();
     };
 
@@ -188,7 +189,7 @@ const ClassList = () => {
         const classRef = doc(db, 'classes', classToUpdate.id);
         await updateDoc(classRef, { students: updatedStudents });
         setSelectedClass((prev) => ({ ...prev, students: updatedStudents }));
-        setSuccess('Student removed successfully');
+        addAlert('success', 'Student removed successfully');
         fetchClasses();
     };
 
@@ -360,7 +361,6 @@ const ClassList = () => {
                 </div>
             )}
 
-            {success && <p className="text-success small mt-3">{success}</p>}
         </div>
     );
 };

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -15,8 +15,10 @@ import {
 import SubjectModal from './modals/SubjectModal.jsx';
 import AddTutorsModal from './modals/AddTutorsModal.jsx';
 import SubjectRow from './SubjectRow.jsx';
+import useAlert from '@/hooks/useAlert';
 
 const SubjectList = () => {
+    const { addAlert } = useAlert();
     const [subjects, setSubjects] = useState([]);
     const [searchTerm, setSearchTerm] = useState('');
     const [showModal, setShowModal] = useState(false);
@@ -56,9 +58,11 @@ const SubjectList = () => {
                 ),
             );
             setIsEditing(false);
+            addAlert('success', 'Subject updated successfully');
         } else {
             const docRef = await addDoc(collection(db, 'subjects'), subject);
             setSubjects([...subjects, { id: docRef.id, ...subject }]);
+            addAlert('success', 'Subject added successfully');
         }
         setShowModal(false);
     };
@@ -73,6 +77,7 @@ const SubjectList = () => {
         if (subjectToDelete) {
             await deleteDoc(doc(db, 'subjects', subjectToDelete.id));
             setSubjects(subjects.filter((subject) => subject.id !== subjectToDelete.id));
+            addAlert('success', 'Subject deleted successfully');
         }
     };
 
@@ -100,6 +105,7 @@ const SubjectList = () => {
         );
         setShowTutorModal(false);
         setTutorsToAdd('');
+        addAlert('success', 'Tutors added successfully');
     };
 
     const handleRemoveTutor = async (tutor, subject) => {
@@ -111,6 +117,7 @@ const SubjectList = () => {
                 sub.id === subject.id ? { ...sub, tutors: updatedTutors } : sub,
             ),
         );
+        addAlert('success', 'Tutor removed successfully');
     };
 
     const openAddModal = () => {


### PR DESCRIPTION
Closes #84

## Summary

- **`ClassList.jsx`**: removed the `success` state variable and its inline `<p>` render. All six feedback points (two validation errors + four success operations) now call `addAlert()` with the correct type (`'error'` for validation, `'success'` for mutations).
- **`SubjectList.jsx`**: added `useAlert` and wired `addAlert('success', ...)` to every mutating operation — add/edit subject, delete subject, add tutors, remove tutor — replacing the previous silent behaviour.

## Test plan

- [x] Add a class without selecting a subject → error toast appears
- [x] Add a class without selecting a teacher → error toast appears
- [x] Add a valid class → success toast appears
- [x] Edit a class → success toast appears
- [x] Delete a class → success toast appears
- [x] Add students to a class → success toast appears
- [x] Remove a student from a class → success toast appears
- [x] Add a subject → success toast appears
- [x] Edit a subject → success toast appears
- [x] Delete a subject → success toast appears
- [x] Add tutors to a subject → success toast appears
- [x] Remove a tutor from a subject → success toast appears
- [x] Confirm no leftover inline `<p>` feedback text appears anywhere

https://claude.ai/code/session_012FwtcTcAymbwowTR3Fu5yN

---
_Generated by [Claude Code](https://claude.ai/code/session_012FwtcTcAymbwowTR3Fu5yN)_