### PR TITLE
fix(security): sanitize HTML in MS Graph email body and event descriptions

### DIFF
--- a/src/app/api/microsoft/msGraphFunctions.js
+++ b/src/app/api/microsoft/msGraphFunctions.js
@@ -38,7 +38,7 @@ const buildEventBody = (subject, description, startTime, endTime, attendeesEmail
     const eventBody = {
         subject: subject,
         body: {
-            contentType: 'HTML',
+            contentType: 'Text',
             content: description || '',
         },
         start: {
@@ -312,7 +312,7 @@ export const msUpdateOccurrence = async (accessToken, occurrenceId, { subject, d
             body: JSON.stringify({
                 subject: subject,
                 body: {
-                    contentType: 'HTML',
+                    contentType: 'Text',
                     content: description || '',
                 },
                 start: {

--- a/src/app/api/send-emails/route.js
+++ b/src/app/api/send-emails/route.js
@@ -90,6 +90,15 @@ export async function POST(req) {
 
 /* ── HTML helpers ──────────────────────────────────────────────────────── */
 
+function escapeHtml(str) {
+    return String(str ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 function formatDate(value) {
     const date = value?.toDate ? value.toDate() : new Date(value);
 
@@ -115,7 +124,7 @@ function buildEventRow(notification, index, total) {
                   </td>
                 </tr>
               </table>
-              <h3 style="margin:0 0 8px 0;color:#111827;font-size:16px;font-weight:700;">${notification.title}</h3>
+              <h3 style="margin:0 0 8px 0;color:#111827;font-size:16px;font-weight:700;">${escapeHtml(notification.title)}</h3>
               <p style="margin:0;color:#374151;font-size:13px;line-height:1.6;">
                 <span style="color:#1e40af;font-weight:600;">When:</span>&nbsp; ${formatDate(notification.start)} &ndash; ${formatDate(notification.end)}
               </p>
@@ -137,7 +146,7 @@ function buildEventRow(notification, index, total) {
                   </td>
                 </tr>
               </table>
-              <h3 style="margin:0 0 10px 0;color:#111827;font-size:16px;font-weight:700;">${notification.title}</h3>
+              <h3 style="margin:0 0 10px 0;color:#111827;font-size:16px;font-weight:700;">${escapeHtml(notification.title)}</h3>
               <p style="margin:0 0 4px 0;color:#9ca3af;font-size:13px;text-decoration:line-through;">
                 ${formatDate(notification.previousStart)} &ndash; ${formatDate(notification.previousEnd)}
               </p>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **HTML injection in email template**: `notification.title` (sourced from Firestore event data) was interpolated raw into the HTML email template in `send-emails/route.js`. An event title containing HTML characters (e.g. `<img onerror=...>`) would be rendered as HTML by email clients, affecting all tutor recipients. Fixed by adding an `escapeHtml` helper and applying it to `notification.title` in both `buildEventRow` branches.

- **Plain-text description sent as HTML to MS Graph**: `buildEventBody` and `msUpdateOccurrence` in `msGraphFunctions.js` used `contentType: 'HTML'` for the event description field, which is a plain-text `<textarea>`. Any `<`, `>`, `&` characters entered by a user would be interpreted as HTML when the event renders in Teams or Outlook. Fixed by changing `contentType` from `'HTML'` to `'Text'`.

## Test plan

- [ ] Create a shift with a title containing `<b>bold</b>` or `<img src=x onerror=alert(1)>` — confirm the email recipient sees the literal text, not rendered HTML
- [ ] Create a Teams meeting event with a description containing `<script>` or `&amp;` — confirm the description appears as plain text in the Teams calendar entry
- [ ] Normal shift emails (allocated / moved) still render correctly with proper formatting
- [ ] Creating and updating recurring events still works end-to-end

https://claude.ai/code/session_01YN29h7PxSzRJpS2ur8YmhD
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN29h7PxSzRJpS2ur8YmhD)_