### PR TITLE
fix: address table styling PR review comments

### DIFF
--- a/src/components/ClassRow.jsx
+++ b/src/components/ClassRow.jsx
@@ -49,8 +49,6 @@ const ClassRow = ({
                         <button
                             onClick={() => handleExpandClass(cls)}
                             className="btn btn-sm btn-outline-secondary"
-                            data-bs-toggle="collapse"
-                            data-bs-target={`#${collapseId}`}
                             aria-expanded={isExpanded}
                             aria-controls={collapseId}
                         >

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -78,6 +78,7 @@ const SubjectList = () => {
         if (subjectToDelete) {
             await deleteDoc(doc(db, 'subjects', subjectToDelete.id));
             setSubjects(subjects.filter((subject) => subject.id !== subjectToDelete.id));
+            setExpandedSubjects((prev) => { const s = new Set(prev); s.delete(subjectToDelete.id); return s; });
             addAlert('success', 'Subject deleted successfully');
         }
     };

--- a/src/components/UserRolesManager.jsx
+++ b/src/components/UserRolesManager.jsx
@@ -283,8 +283,8 @@ const UserRolesManager = () => {
                     <thead>
                         <tr>
                             <th scope="col">User</th>
-                            <th scope="col" style={{ width: '360px' }}>Roles</th>
-                            <th scope="col" style={{ width: '180px' }} className={t.actionCol}>Actions</th>
+                            <th scope="col" style={{ width: '30%' }}>Roles</th>
+                            <th scope="col" style={{ width: '20%' }} className={t.actionCol}>Actions</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/src/styles/manageTable.module.css
+++ b/src/styles/manageTable.module.css
@@ -74,9 +74,9 @@
 }
 
 /* ── Expandable panel ────────────────────────────────────────────── */
-.expandRow td {
-    padding: 0 !important;
-    border-bottom: none !important;
+.table .expandRow td {
+    padding: 0;
+    border-bottom: none;
 }
 
 .expandPanel {


### PR DESCRIPTION
Addresses the unresolved review comments on #83.

## Changes

- **ClassRow.jsx** — Removed `data-bs-toggle` and `data-bs-target` from the expand button. Bootstrap JS was independently managing the collapse alongside React state, which could cause misfires. Visibility is already controlled by React via the `collapse show` className.
- **SubjectList.jsx** — `handleDeleteSubject` now clears the deleted subject's ID from `expandedSubjects`, matching the pattern already in `ClassList`. Prevents a deleted-then-recreated subject from re-appearing expanded.
- **UserRolesManager.jsx** — Replaced fixed `360px`/`180px` column widths with `30%`/`20%` so the table remains usable on narrower viewports.
- **manageTable.module.css** — Replaced `!important` on `.expandRow td` with the more specific `.table .expandRow td` selector (specificity 0-2-1 beats Bootstrap's `.table tbody td` at 0-1-2), removing the need for `!important`.

## Test plan

- [ ] Expand/collapse students in Manage Class — confirm React state drives toggle, no double-fire
- [ ] Delete an expanded subject, re-add it — confirm it renders collapsed
- [ ] Manage Role page on a narrow viewport (~768 px) — confirm Actions column is visible
- [ ] Expand row padding is zero, no bottom border leaking through

---
_Generated by [Claude Code](https://claude.ai/code/session_01R57HQ8WxzLs3BkfzWGVxbc)_