### PR TITLE
Add email deduplication and duplicate-name validation

### DIFF
--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -15,6 +15,13 @@ import ClassRow from './ClassRow.jsx';
 import ClassModal from './modals/ClassModal.jsx';
 import AddStudentsModal from './modals/AddStudentsModal.jsx';
 import useAlert from '@/hooks/useAlert';
+import useToggleSet from '@/hooks/useToggleSet';
+import { checkDuplicateName } from '@/utils/validation';
+import {
+    parseStudentEntries,
+    filterNewStudentEntries,
+    extractEmailFromEntry,
+} from '@/utils/emailUtils';
 import t from '@/styles/manageTable.module.css';
 
 const ClassList = () => {
@@ -32,7 +39,7 @@ const ClassList = () => {
     const [studentsToAdd, setStudentsToAdd] = useState('');
     const [selectedClass, setSelectedClass] = useState(null);
     const [filteredClasses, setFilteredClasses] = useState([]);
-    const [expandedClasses, setExpandedClasses] = useState(new Set());
+    const [expandedClasses, toggleExpandedClass, removeExpandedClass] = useToggleSet();
 
     const fetchClasses = async () => {
         const querySnapshot = await getDocs(collection(db, 'classes'));
@@ -92,12 +99,7 @@ const ClassList = () => {
             return false;
         }
 
-        const isDuplicateName = classes.some(
-            (cls) =>
-                cls.name.toLowerCase() === className.toLowerCase() &&
-                cls.id !== selectedClass?.id,
-        );
-        if (isDuplicateName) {
+        if (checkDuplicateName(classes, className, selectedClass?.id)) {
             addAlert('error', 'A class with this name already exists.');
             return;
         }        
@@ -156,23 +158,18 @@ const ClassList = () => {
         if (classToDelete) {
             await deleteDoc(doc(db, 'classes', classToDelete.id));
             setClasses(classes.filter((cls) => cls.id !== classToDelete.id));
-            setExpandedClasses((prev) => { const s = new Set(prev); s.delete(classToDelete.id); return s; });
+            removeExpandedClass(classToDelete.id);
             addAlert('success', 'Class deleted successfully');
         }
     };
 
     const handleAddStudents = async (e) => {
         e.preventDefault();
-        const rawEntries = studentsToAdd.split(',').map((entry) => entry.trim()).filter(Boolean);
-
-        const existingEmails = new Set((selectedClass.students || []).map((s) => s.email));
-        const seenEmails = new Set();
-        const uniqueEntries = rawEntries.filter((entry) => {
-            const email = entry.includes(':') ? entry.split(':')[1].trim() : entry;
-            if (seenEmails.has(email) || existingEmails.has(email)) return false;
-            seenEmails.add(email);
-            return true;
-        });
+        const rawEntries = parseStudentEntries(studentsToAdd);
+        const uniqueEntries = filterNewStudentEntries(
+            rawEntries,
+            (selectedClass.students || []).map((s) => s.email),
+        );
 
         if (uniqueEntries.length === 0) {
             addAlert('error', 'All provided emails are already enrolled in this class.');
@@ -181,13 +178,8 @@ const ClassList = () => {
 
         const newStudents = await Promise.all(
             uniqueEntries.map(async (entry) => {
-                let email, name;
-                if (entry.includes(':')) {
-                    [name, email] = entry.split(':').map((s) => s.trim());
-                } else {
-                    email = entry;
-                    name = '';
-                }
+                const email = extractEmailFromEntry(entry);
+                const name = entry.includes(':') ? entry.split(':')[0].trim() : '';
 
                 const userRef = doc(db, 'users', email);
                 const userDoc = await getDoc(userRef);
@@ -224,13 +216,7 @@ const ClassList = () => {
         setShowStudentModal(true);
     };
 
-    const handleExpandClass = (cls) => {
-        setExpandedClasses((prev) => {
-            const s = new Set(prev);
-            s.has(cls.id) ? s.delete(cls.id) : s.add(cls.id);
-            return s;
-        });
-    };
+    const handleExpandClass = (cls) => toggleExpandedClass(cls.id);
 
     return (
         <div className={t.container}>

--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -92,6 +92,16 @@ const ClassList = () => {
             return false;
         }
 
+        const isDuplicateName = classes.some(
+            (cls) =>
+                cls.name.toLowerCase() === className.toLowerCase() &&
+                cls.id !== selectedClass?.id,
+        );
+        if (isDuplicateName) {
+            addAlert('error', 'A class with this name already exists.');
+            return;
+        }        
+
         try {
             if (isEditing) {
                 const classRef = doc(db, 'classes', selectedClass.id);
@@ -130,9 +140,9 @@ const ClassList = () => {
             console.error('Failed to save class:', err);
             addAlert('error', 'Failed to save class. Please try again.');
             return false;
-        }
-    };
-
+        };
+    }
+    
     const handleEditClass = (cls) => {
         setSelectedClass(cls);
         setClassName(cls.name);
@@ -153,11 +163,24 @@ const ClassList = () => {
 
     const handleAddStudents = async (e) => {
         e.preventDefault();
-        const entries = studentsToAdd.split(',').map((entry) => entry.trim());
+        const rawEntries = studentsToAdd.split(',').map((entry) => entry.trim()).filter(Boolean);
+
+        const existingEmails = new Set((selectedClass.students || []).map((s) => s.email));
+        const seenEmails = new Set();
+        const uniqueEntries = rawEntries.filter((entry) => {
+            const email = entry.includes(':') ? entry.split(':')[1].trim() : entry;
+            if (seenEmails.has(email) || existingEmails.has(email)) return false;
+            seenEmails.add(email);
+            return true;
+        });
+
+        if (uniqueEntries.length === 0) {
+            addAlert('error', 'All provided emails are already enrolled in this class.');
+            return;
+        }
 
         const newStudents = await Promise.all(
-            entries.map(async (entry) => {
-                // Check if entry has name:email format (from CSV) or just email (manual)
+            uniqueEntries.map(async (entry) => {
                 let email, name;
                 if (entry.includes(':')) {
                     [name, email] = entry.split(':').map((s) => s.trim());
@@ -169,11 +192,9 @@ const ClassList = () => {
                 const userRef = doc(db, 'users', email);
                 const userDoc = await getDoc(userRef);
                 if (!userDoc.exists()) {
-                    // User doesn't exist - use name from CSV or empty string
                     return { email, name };
                 } else {
                     const userData = userDoc.data();
-                    // Prefer name from database, fallback to CSV name, then empty
                     return { email, name: userData.name || name || '' };
                 }
             }),

--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -101,8 +101,8 @@ const ClassList = () => {
 
         if (checkDuplicateName(classes, className, selectedClass?.id)) {
             addAlert('error', 'A class with this name already exists.');
-            return;
-        }        
+            return false;
+        }
 
         try {
             if (isEditing) {

--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -143,7 +143,7 @@ const ClassList = () => {
             addAlert('error', 'Failed to save class. Please try again.');
             return false;
         };
-    }
+    };
     
     const handleEditClass = (cls) => {
         setSelectedClass(cls);

--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -203,8 +203,8 @@ const ClassList = () => {
             setSelectedClass((prev) => ({ ...prev, students: updatedStudents }));
             setStudentsToAdd('');
             setShowStudentModal(false);
+            await fetchClasses();
             addAlert('success', 'Students added successfully');
-            fetchClasses();
         } catch (err) {
             console.error('Failed to add students:', err);
             addAlert('error', 'Failed to add students. Please try again.');

--- a/src/components/ClassList.jsx
+++ b/src/components/ClassList.jsx
@@ -142,7 +142,7 @@ const ClassList = () => {
             console.error('Failed to save class:', err);
             addAlert('error', 'Failed to save class. Please try again.');
             return false;
-        };
+        }
     };
     
     const handleEditClass = (cls) => {
@@ -156,10 +156,15 @@ const ClassList = () => {
 
     const handleDeleteClass = async (classToDelete) => {
         if (classToDelete) {
-            await deleteDoc(doc(db, 'classes', classToDelete.id));
-            setClasses(classes.filter((cls) => cls.id !== classToDelete.id));
-            removeExpandedClass(classToDelete.id);
-            addAlert('success', 'Class deleted successfully');
+            try {
+                await deleteDoc(doc(db, 'classes', classToDelete.id));
+                setClasses(classes.filter((cls) => cls.id !== classToDelete.id));
+                removeExpandedClass(classToDelete.id);
+                addAlert('success', 'Class deleted successfully');
+            } catch (err) {
+                console.error('Failed to delete class:', err);
+                addAlert('error', 'Failed to delete class. Please try again.');
+            }
         }
     };
 
@@ -173,32 +178,38 @@ const ClassList = () => {
 
         if (uniqueEntries.length === 0) {
             addAlert('error', 'All provided emails are already enrolled in this class.');
-            return;
+            return false;
         }
 
-        const newStudents = await Promise.all(
-            uniqueEntries.map(async (entry) => {
-                const email = extractEmailFromEntry(entry);
-                const name = entry.includes(':') ? entry.split(':')[0].trim() : '';
+        try {
+            const newStudents = await Promise.all(
+                uniqueEntries.map(async (entry) => {
+                    const email = extractEmailFromEntry(entry);
+                    const name = entry.includes(':') ? entry.split(':')[0].trim() : '';
 
-                const userRef = doc(db, 'users', email);
-                const userDoc = await getDoc(userRef);
-                if (!userDoc.exists()) {
-                    return { email, name };
-                } else {
-                    const userData = userDoc.data();
-                    return { email, name: userData.name || name || '' };
-                }
-            }),
-        );
-        const updatedStudents = [...(selectedClass.students || []), ...newStudents];
-        const classRef = doc(db, 'classes', selectedClass.id);
-        await updateDoc(classRef, { students: updatedStudents });
-        setSelectedClass((prev) => ({ ...prev, students: updatedStudents }));
-        setStudentsToAdd('');
-        setShowStudentModal(false);
-        addAlert('success', 'Students added successfully');
-        fetchClasses();
+                    const userRef = doc(db, 'users', email);
+                    const userDoc = await getDoc(userRef);
+                    if (!userDoc.exists()) {
+                        return { email, name };
+                    } else {
+                        const userData = userDoc.data();
+                        return { email, name: userData.name || name || '' };
+                    }
+                }),
+            );
+            const updatedStudents = [...(selectedClass.students || []), ...newStudents];
+            const classRef = doc(db, 'classes', selectedClass.id);
+            await updateDoc(classRef, { students: updatedStudents });
+            setSelectedClass((prev) => ({ ...prev, students: updatedStudents }));
+            setStudentsToAdd('');
+            setShowStudentModal(false);
+            addAlert('success', 'Students added successfully');
+            fetchClasses();
+        } catch (err) {
+            console.error('Failed to add students:', err);
+            addAlert('error', 'Failed to add students. Please try again.');
+            return false;
+        }
     };
 
     const handleRemoveStudent = async (classToUpdate, studentToRemove) => {

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -18,6 +18,9 @@ import SubjectModal from './modals/SubjectModal.jsx';
 import AddTutorsModal from './modals/AddTutorsModal.jsx';
 import SubjectRow from './SubjectRow.jsx';
 import useAlert from '@/hooks/useAlert';
+import useToggleSet from '@/hooks/useToggleSet';
+import { checkDuplicateName } from '@/utils/validation';
+import { filterNewEmails } from '@/utils/emailUtils';
 import t from '@/styles/manageTable.module.css';
 
 const SubjectList = () => {
@@ -30,7 +33,7 @@ const SubjectList = () => {
     const [showTutorModal, setShowTutorModal] = useState(false);
     const [selectedSubject, setSelectedSubject] = useState(null);
     const [tutorsToAdd, setTutorsToAdd] = useState('');
-    const [expandedSubjects, setExpandedSubjects] = useState(new Set());
+    const [expandedSubjects, toggleExpandedSubject, removeExpandedSubject] = useToggleSet();
     const [filteredSubjects, setFilteredSubjects] = useState([]);
 
     useEffect(() => {
@@ -52,12 +55,7 @@ const SubjectList = () => {
     }, [searchTerm, subjects]);
 
     const handleAddSubject = async (subject) => {
-        const isDuplicateName = subjects.some(
-            (sub) =>
-                sub.name.toLowerCase() === subject.name.toLowerCase() &&
-                sub.id !== currentSubject?.id,
-        );
-        if (isDuplicateName) {
+        if (checkDuplicateName(subjects, subject.name, currentSubject?.id)) {
             addAlert('error', 'A subject with this name already exists.');
             return;
         }
@@ -90,16 +88,16 @@ const SubjectList = () => {
         if (subjectToDelete) {
             await deleteDoc(doc(db, 'subjects', subjectToDelete.id));
             setSubjects(subjects.filter((subject) => subject.id !== subjectToDelete.id));
-            setExpandedSubjects((prev) => { const s = new Set(prev); s.delete(subjectToDelete.id); return s; });
+            removeExpandedSubject(subjectToDelete.id);
             addAlert('success', 'Subject deleted successfully');
         }
     };
 
     const handleAddTutors = async (emails) => {
-        const existingTutorEmails = new Set((selectedSubject.tutors || []).map((t) => t.email));
-        const uniqueEmails = [
-            ...new Set(emails.map((email) => email.trim()).filter((email) => email !== '')),
-        ].filter((email) => !existingTutorEmails.has(email));
+        const uniqueEmails = filterNewEmails(
+            emails,
+            (selectedSubject.tutors || []).map((t) => t.email),
+        );
         if (uniqueEmails.length === 0) {
             addAlert('error', 'All provided emails are already assigned to this subject.');
             return;
@@ -113,13 +111,12 @@ const SubjectList = () => {
         const usersCollection = collection(db, 'users');
         const existingUsersMap = new Map();
 
-        // fetch existing users in chunks of 30 (Firestore 'in' query limit) 
+        // fetch existing users in chunks of 30 (Firestore 'in' query limit)
         const chunks = [];
         for (let i = 0; i < uniqueEmails.length; i += 30) {
             chunks.push(uniqueEmails.slice(i, i + 30));
         }
 
-        // Promise.all to ensure they fire in parallel
         const snapshots = await Promise.all(
             chunks.map((chunk) => {
                 const q = query(usersCollection, where(documentId(), 'in', chunk));
@@ -139,7 +136,7 @@ const SubjectList = () => {
                 return { email, name: userData.name || '' };
             } else {
                 const userRef = doc(db, 'users', email);
-                batch.set(userRef, { email, role: 'tutor', defaultRole: 'tutor'}, { merge: true });
+                batch.set(userRef, { email, role: 'tutor', defaultRole: 'tutor' }, { merge: true });
                 return { email, name: '' };
             }
         });
@@ -197,13 +194,7 @@ const SubjectList = () => {
         setShowTutorModal(true);
     };
 
-    const handleExpandSubject = (subject) => {
-        setExpandedSubjects((prev) => {
-            const s = new Set(prev);
-            s.has(subject.id) ? s.delete(subject.id) : s.add(subject.id);
-            return s;
-        });
-    };
+    const handleExpandSubject = (subject) => toggleExpandedSubject(subject.id);
 
     return (
         <div className={t.container}>

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -57,7 +57,7 @@ const SubjectList = () => {
     const handleAddSubject = async (subject) => {
         if (checkDuplicateName(subjects, subject.name, currentSubject?.id)) {
             addAlert('error', 'A subject with this name already exists.');
-            return;
+            return false;
         }
 
         if (isEditing) {

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -52,6 +52,16 @@ const SubjectList = () => {
     }, [searchTerm, subjects]);
 
     const handleAddSubject = async (subject) => {
+        const isDuplicateName = subjects.some(
+            (sub) =>
+                sub.name.toLowerCase() === subject.name.toLowerCase() &&
+                sub.id !== currentSubject?.id,
+        );
+        if (isDuplicateName) {
+            addAlert('error', 'A subject with this name already exists.');
+            return;
+        }
+
         if (isEditing) {
             const subjectRef = doc(db, 'subjects', currentSubject.id);
             await updateDoc(subjectRef, subject);
@@ -86,10 +96,14 @@ const SubjectList = () => {
     };
 
     const handleAddTutors = async (emails) => {
+        const existingTutorEmails = new Set((selectedSubject.tutors || []).map((t) => t.email));
         const uniqueEmails = [
             ...new Set(emails.map((email) => email.trim()).filter((email) => email !== '')),
-        ];
-        if (uniqueEmails.length === 0) return;
+        ].filter((email) => !existingTutorEmails.has(email));
+        if (uniqueEmails.length === 0) {
+            addAlert('error', 'All provided emails are already assigned to this subject.');
+            return;
+        }
         if (uniqueEmails.length > 499) {
             addAlert('error', 'Too many tutors at once — please add 499 or fewer at a time.');
             return;

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -86,10 +86,15 @@ const SubjectList = () => {
 
     const handleDeleteSubject = async (subjectToDelete) => {
         if (subjectToDelete) {
-            await deleteDoc(doc(db, 'subjects', subjectToDelete.id));
-            setSubjects(subjects.filter((subject) => subject.id !== subjectToDelete.id));
-            removeExpandedSubject(subjectToDelete.id);
-            addAlert('success', 'Subject deleted successfully');
+            try {
+                await deleteDoc(doc(db, 'subjects', subjectToDelete.id));
+                setSubjects(subjects.filter((subject) => subject.id !== subjectToDelete.id));
+                removeExpandedSubject(subjectToDelete.id);
+                addAlert('success', 'Subject deleted successfully');
+            } catch (err) {
+                console.error('Failed to delete subject:', err);
+                addAlert('error', 'Failed to delete subject. Please try again.');
+            }
         }
     };
 

--- a/src/components/SubjectList.jsx
+++ b/src/components/SubjectList.jsx
@@ -60,22 +60,28 @@ const SubjectList = () => {
             return false;
         }
 
-        if (isEditing) {
-            const subjectRef = doc(db, 'subjects', currentSubject.id);
-            await updateDoc(subjectRef, subject);
-            setSubjects(
-                subjects.map((sub) =>
-                    sub.id === currentSubject.id ? { ...sub, ...subject } : sub,
-                ),
-            );
-            setIsEditing(false);
-            addAlert('success', 'Subject updated successfully');
-        } else {
-            const docRef = await addDoc(collection(db, 'subjects'), subject);
-            setSubjects([...subjects, { id: docRef.id, ...subject }]);
-            addAlert('success', 'Subject added successfully');
+        try {
+            if (isEditing) {
+                const subjectRef = doc(db, 'subjects', currentSubject.id);
+                await updateDoc(subjectRef, subject);
+                setSubjects(
+                    subjects.map((sub) =>
+                        sub.id === currentSubject.id ? { ...sub, ...subject } : sub,
+                    ),
+                );
+                setIsEditing(false);
+                addAlert('success', 'Subject updated successfully');
+            } else {
+                const docRef = await addDoc(collection(db, 'subjects'), subject);
+                setSubjects([...subjects, { id: docRef.id, ...subject }]);
+                addAlert('success', 'Subject added successfully');
+            }
+            setShowModal(false);
+        } catch (err) {
+            console.error('Failed to save subject:', err);
+            addAlert('error', 'Failed to save subject. Please try again.');
+            return false;
         }
-        setShowModal(false);
     };
 
     const handleEditSubject = (subject) => {
@@ -122,76 +128,72 @@ const SubjectList = () => {
             chunks.push(uniqueEmails.slice(i, i + 30));
         }
 
-        const snapshots = await Promise.all(
-            chunks.map((chunk) => {
-                const q = query(usersCollection, where(documentId(), 'in', chunk));
-                return getDocs(q);
-            }),
-        );
-
-        snapshots.forEach((querySnapshot) => {
-            querySnapshot.forEach((docSnap) => {
-                existingUsersMap.set(docSnap.id, docSnap.data());
-            });
-        });
-
-        const newTutors = uniqueEmails.map((email) => {
-            if (existingUsersMap.has(email)) {
-                const userData = existingUsersMap.get(email);
-                return { email, name: userData.name || '' };
-            } else {
-                const userRef = doc(db, 'users', email);
-                batch.set(userRef, { email, role: 'tutor', defaultRole: 'tutor' }, { merge: true });
-                return { email, name: '' };
-            }
-        });
-
-        const updatedTutors = [...(selectedSubject.tutors || []), ...newTutors];
-        const subjectRef = doc(db, 'subjects', selectedSubject.id);
-        batch.update(subjectRef, { tutors: updatedTutors });
-
         try {
+            const snapshots = await Promise.all(
+                chunks.map((chunk) => {
+                    const q = query(usersCollection, where(documentId(), 'in', chunk));
+                    return getDocs(q);
+                }),
+            );
+
+            snapshots.forEach((querySnapshot) => {
+                querySnapshot.forEach((docSnap) => {
+                    existingUsersMap.set(docSnap.id, docSnap.data());
+                });
+            });
+
+            const newTutors = uniqueEmails.map((email) => {
+                if (existingUsersMap.has(email)) {
+                    const userData = existingUsersMap.get(email);
+                    return { email, name: userData.name || '' };
+                } else {
+                    const userRef = doc(db, 'users', email);
+                    batch.set(userRef, { email, role: 'tutor', defaultRole: 'tutor' }, { merge: true });
+                    return { email, name: '' };
+                }
+            });
+
+            const updatedTutors = [...(selectedSubject.tutors || []), ...newTutors];
+            const subjectRef = doc(db, 'subjects', selectedSubject.id);
+            batch.update(subjectRef, { tutors: updatedTutors });
+
             await batch.commit();
+
+            setSubjects(
+                subjects.map((sub) =>
+                    sub.id === selectedSubject.id ? { ...sub, tutors: updatedTutors } : sub,
+                ),
+            );
+            setShowTutorModal(false);
+            setTutorsToAdd('');
+            addAlert('success', 'Tutors added successfully');
         } catch (err) {
             console.error('Failed to add tutors:', err);
             addAlert('error', 'Failed to save tutors. Please try again.');
-            return;
         }
-
-        setSubjects(
-            subjects.map((sub) =>
-                sub.id === selectedSubject.id ? { ...sub, tutors: updatedTutors } : sub,
-            ),
-        );
-        setShowTutorModal(false);
-        setTutorsToAdd('');
-        addAlert('success', 'Tutors added successfully');
     };
 
     const handleRemoveTutor = async (tutor, subject) => {
         const updatedTutors = subject.tutors.filter((t) => t.email !== tutor.email);
         const subjectRef = doc(db, 'subjects', subject.id);
-        await updateDoc(subjectRef, { tutors: updatedTutors });
-        setSubjects(
-            subjects.map((sub) =>
-                sub.id === subject.id ? { ...sub, tutors: updatedTutors } : sub,
-            ),
-        );
-        addAlert('success', 'Tutor removed successfully');
+        try {
+            await updateDoc(subjectRef, { tutors: updatedTutors });
+            setSubjects(
+                subjects.map((sub) =>
+                    sub.id === subject.id ? { ...sub, tutors: updatedTutors } : sub,
+                ),
+            );
+            addAlert('success', 'Tutor removed successfully');
+        } catch (err) {
+            console.error('Failed to remove tutor:', err);
+            addAlert('error', 'Failed to remove tutor. Please try again.');
+        }
     };
 
     const openAddModal = () => {
         setCurrentSubject(null);
         setIsEditing(false);
         setShowModal(true);
-    };
-
-    const openEditModal = (subject) => {
-        handleEditSubject(subject);
-    };
-
-    const openDeleteModal = (subject) => {
-        handleDeleteSubject(subject);
     };
 
     const openAddTutorModal = (subject) => {
@@ -219,7 +221,7 @@ const SubjectList = () => {
                     onClick={openAddModal}
                     className="btn btn-outline-primary btn-sm text-nowrap"
                 >
-                    {isEditing ? 'Edit Subject' : 'Add Subject'}
+                    Add Subject
                 </button>
             </div>
 
@@ -237,11 +239,11 @@ const SubjectList = () => {
                                 key={subject.id}
                                 subject={subject}
                                 handleOpenTutorModal={openAddTutorModal}
-                                confirmDeleteSubject={openDeleteModal}
+                                confirmDeleteSubject={handleDeleteSubject}
                                 handleExpandSubject={handleExpandSubject}
                                 expandedSubjects={expandedSubjects}
                                 confirmRemoveTutor={handleRemoveTutor}
-                                handleEditSubject={openEditModal}
+                                handleEditSubject={handleEditSubject}
                             />
                         ))}
                     </tbody>

--- a/src/components/modals/SubjectModal.jsx
+++ b/src/components/modals/SubjectModal.jsx
@@ -13,7 +13,6 @@ const SubjectModal = ({ showModal, setShowModal, subject, handleSubmit }) => {
     const handleFormSubmit = (e) => {
         e.preventDefault();
         handleSubmit({ name: subjectName });
-        setShowModal(false);
     };
 
     return (

--- a/src/components/modals/SubjectModal.jsx
+++ b/src/components/modals/SubjectModal.jsx
@@ -12,7 +12,7 @@ const SubjectModal = ({ showModal, setShowModal, subject, handleSubmit }) => {
 
     const handleFormSubmit = (e) => {
         e.preventDefault();
-        handleSubmit({ name: subjectName });
+        return handleSubmit({ name: subjectName });
     };
 
     return (

--- a/src/hooks/useToggleSet.js
+++ b/src/hooks/useToggleSet.js
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+
+const useToggleSet = () => {
+    const [set, setSet] = useState(new Set());
+
+    const toggle = (id) => {
+        setSet((prev) => {
+            const s = new Set(prev);
+            s.has(id) ? s.delete(id) : s.add(id);
+            return s;
+        });
+    };
+
+    const remove = (id) => {
+        setSet((prev) => {
+            const s = new Set(prev);
+            s.delete(id);
+            return s;
+        });
+    };
+
+    return [set, toggle, remove];
+};
+
+export default useToggleSet;

--- a/src/utils/emailUtils.js
+++ b/src/utils/emailUtils.js
@@ -1,0 +1,26 @@
+export const parseStudentEntries = (commaSeparated) =>
+    commaSeparated
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+
+export const extractEmailFromEntry = (entry) =>
+    entry.includes(':') ? entry.split(':')[1].trim() : entry;
+
+export const filterNewStudentEntries = (entries, existingEmails) => {
+    const existingSet = new Set(existingEmails);
+    const seenEmails = new Set();
+    return entries.filter((entry) => {
+        const email = extractEmailFromEntry(entry);
+        if (seenEmails.has(email) || existingSet.has(email)) return false;
+        seenEmails.add(email);
+        return true;
+    });
+};
+
+export const filterNewEmails = (emails, existingEmails) => {
+    const existingSet = new Set(existingEmails);
+    return [...new Set(emails.map((e) => e.trim()).filter(Boolean))].filter(
+        (email) => !existingSet.has(email),
+    );
+};

--- a/src/utils/emailUtils.js
+++ b/src/utils/emailUtils.js
@@ -4,11 +4,13 @@ export const parseStudentEntries = (commaSeparated) =>
         .map((entry) => entry.trim())
         .filter(Boolean);
 
-export const extractEmailFromEntry = (entry) =>
-    entry.includes(':') ? entry.split(':')[1].trim() : entry;
+export const extractEmailFromEntry = (entry) => {
+    const raw = entry.includes(':') ? entry.split(':')[1].trim() : entry;
+    return raw.toLowerCase();
+};
 
 export const filterNewStudentEntries = (entries, existingEmails) => {
-    const existingSet = new Set(existingEmails);
+    const existingSet = new Set(existingEmails.map((e) => e.toLowerCase()));
     const seenEmails = new Set();
     return entries.filter((entry) => {
         const email = extractEmailFromEntry(entry);
@@ -19,8 +21,8 @@ export const filterNewStudentEntries = (entries, existingEmails) => {
 };
 
 export const filterNewEmails = (emails, existingEmails) => {
-    const existingSet = new Set(existingEmails);
-    return [...new Set(emails.map((e) => e.trim()).filter(Boolean))].filter(
+    const existingSet = new Set(existingEmails.map((e) => e.toLowerCase()));
+    return [...new Set(emails.map((e) => e.trim().toLowerCase()).filter(Boolean))].filter(
         (email) => !existingSet.has(email),
     );
 };

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -1,0 +1,4 @@
+export const checkDuplicateName = (items, name, currentId = null) =>
+    items.some(
+        (item) => item.name.toLowerCase() === name.toLowerCase() && item.id !== currentId,
+    );


### PR DESCRIPTION
Closes #100

## Changes

- **Duplicate class/subject names** — `handleAddClass` and `handleAddSubject` now check for a case-insensitive name match before writing; shows an error and keeps the form open if a duplicate is found. `SubjectModal` no longer closes itself on submit so the form stays open when validation fails.
- **Bulk student deduplication** — `handleAddStudents` collapses duplicate emails within the input and skips any email already enrolled in the class before touching Firestore.
- **Existing tutors filter** — `handleAddTutors` filters out emails already assigned to the subject before the Firestore batch write; shows an error if nothing new remains.

Reported by @outsidermm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJMNZATiFfHpmkN67AwJTh)_