### PR TITLE
fix: sanitize HTML in email templates and remove dead code

### DIFF
--- a/src/app/api/send-emails/route.js
+++ b/src/app/api/send-emails/route.js
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/security/authConfig';
 import { getMicrosoftAccessToken } from '@/lib/microsoft/tokenUtils';
 import { msSendEmail } from '@/app/api/microsoft/msGraphFunctions';
 import { DateTime } from 'luxon';
+import { sanitiseHtml } from '@/lib/security/securityHelpers';
 
 export async function POST(req) {
     const session = await getServerSession(authOptions);
@@ -115,7 +116,7 @@ function buildEventRow(notification, index, total) {
                   </td>
                 </tr>
               </table>
-              <h3 style="margin:0 0 8px 0;color:#111827;font-size:16px;font-weight:700;">${notification.title}</h3>
+              <h3 style="margin:0 0 8px 0;color:#111827;font-size:16px;font-weight:700;">${sanitiseHtml(notification.title)}</h3>
               <p style="margin:0;color:#374151;font-size:13px;line-height:1.6;">
                 <span style="color:#1e40af;font-weight:600;">When:</span>&nbsp; ${formatDate(notification.start)} &ndash; ${formatDate(notification.end)}
               </p>
@@ -137,7 +138,7 @@ function buildEventRow(notification, index, total) {
                   </td>
                 </tr>
               </table>
-              <h3 style="margin:0 0 10px 0;color:#111827;font-size:16px;font-weight:700;">${notification.title}</h3>
+              <h3 style="margin:0 0 10px 0;color:#111827;font-size:16px;font-weight:700;">${sanitiseHtml(notification.title)}</h3>
               <p style="margin:0 0 4px 0;color:#9ca3af;font-size:13px;text-decoration:line-through;">
                 ${formatDate(notification.previousStart)} &ndash; ${formatDate(notification.previousEnd)}
               </p>

--- a/src/components/DashboardOverview.jsx
+++ b/src/components/DashboardOverview.jsx
@@ -194,7 +194,6 @@ const DashboardOverview = () => {
             uniqueStudents: uniqueStudentEmails.size,
             pendingRequests: pendingRequestsData.length,
             approvedRequests: 0,
-            rejectedRequests: 0,
             tutorsScheduledToday: uniqueTutorEmailsToday.size,
             teacherStats: {
                 studentSessions: teacherStudentSessions,

--- a/src/components/forms/StudentEventForm.jsx
+++ b/src/components/forms/StudentEventForm.jsx
@@ -41,11 +41,10 @@ const StudentEventForm = ({
     );
     const [selectedSubject, setSelectedSubject] = useState(newEvent.subject || null);
     const [selectedPreference, setSelectedPreference] = useState(newEvent.preference || null);
-    const [selectedStudent] = useState(
+    const selectedStudent =
         newEvent.students && newEvent.students.length > 0
             ? newEvent.students[0]
-            : { value: studentEmail, label: studentEmail },
-    );
+            : { value: studentEmail, label: studentEmail };
     const { addAlert } = useAlert();
 
     const preferenceOptions = ['Homework (Prep)', 'Assignments', 'Exam Help', 'General'];


### PR DESCRIPTION
Fixes #102

## Changes

- **XSS fix** — `notification.title` in `buildEventRow` (both `allocated` and time-changed branches) is now passed through the existing `sanitiseHtml` helper before being embedded in the HTML email body
- **Dead code removal** — `rejectedRequests: 0` removed from `dashboardData` memo in `DashboardOverview.jsx`; it was declared but never read by any component
- **Unnecessary useState** — `selectedStudent` in `StudentEventForm.jsx` converted from `useState` (with no setter) to a plain `const`, since the value is derived from props and never mutated

Reported by @outsidermm