### PR TITLE
fix: capture modalRef before cleanup and remove stale eslint-disable comment

### DIFF
--- a/src/components/UserRolesManager.jsx
+++ b/src/components/UserRolesManager.jsx
@@ -69,8 +69,9 @@ const UserRolesManager = () => {
 
     useEffect(() => {
         if (showModal && modalRef.current && typeof window !== 'undefined' && window.bootstrap) {
+            const modalElement = modalRef.current;
             // Initialize Bootstrap modal with accessibility features
-            const modalInstance = new window.bootstrap.Modal(modalRef.current, {
+            const modalInstance = new window.bootstrap.Modal(modalElement, {
                 backdrop: 'static',
                 keyboard: true,
                 focus: true,
@@ -87,12 +88,11 @@ const UserRolesManager = () => {
                 setIsEditing(false);
             };
 
-            modalRef.current.addEventListener('hidden.bs.modal', handleModalHidden);
+            modalElement.addEventListener('hidden.bs.modal', handleModalHidden);
 
             return () => {
                 modalInstance.hide();
-                // eslint-disable-next-line react-hooks/exhaustive-deps
-                modalRef.current?.removeEventListener('hidden.bs.modal', handleModalHidden);
+                modalElement.removeEventListener('hidden.bs.modal', handleModalHidden);
             };
         }
     }, [showModal]);
@@ -124,7 +124,7 @@ const UserRolesManager = () => {
             await setDoc(userRef, {
                 email,
                 name,
-                role, // Keep for backward compatibility
+                role, // Legacy single-role mirror for older readers still expecting `users.role`; canonical fields are `defaultRole` + `userRoles`. Remove after all readers migrate.
                 defaultRole: role,
                 userRoles
             }, { merge: true });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Captures `modalRef.current` into a local `modalElement` variable at effect setup time so both `addEventListener` and `removeEventListener` always reference the same stable DOM node (the ref may be null by cleanup time, causing listener leaks)
- Removes the now-pointless `// eslint-disable-next-line react-hooks/exhaustive-deps` comment — it was suppressing a warning about accessing `modalRef.current` inside the cleanup closure, which no longer applies
- Clarifies the legacy `role` field comment to explain when it can be safely removed

## Test plan

- [ ] Open the UserRolesManager modal, close it, and verify no console errors or listener leak warnings
- [ ] Confirm the ESLint rule is satisfied without the suppression comment

https://claude.ai/code/session_01PC32HAdodAXJnz2SJR1PLm
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PC32HAdodAXJnz2SJR1PLm)_