### PR TITLE
Mm/mobile feature/fix

### DIFF
--- a/src/components/ClassRow.jsx
+++ b/src/components/ClassRow.jsx
@@ -52,7 +52,7 @@ const ClassRow = ({
                             aria-expanded={isExpanded}
                             aria-controls={collapseId}
                         >
-                            {isExpanded ? 'Collapse' : 'Expand to view students'}
+                            {isExpanded ? 'Collapse' : 'Expand Students'}
                         </button>
                         <button
                             onClick={() => confirmDeleteClass(cls)}

--- a/src/components/SubjectRow.jsx
+++ b/src/components/SubjectRow.jsx
@@ -40,7 +40,7 @@ const SubjectRow = ({
                             aria-expanded={isExpanded}
                             aria-controls={collapseId}
                         >
-                            {isExpanded ? 'Collapse' : 'Expand to view tutors'}
+                            {isExpanded ? 'Collapse' : 'Expand Tutors'}
                         </button>
                         <button
                             onClick={() => confirmDeleteSubject(subject)}

--- a/src/components/UserRolesManager.jsx
+++ b/src/components/UserRolesManager.jsx
@@ -282,27 +282,29 @@ const UserRolesManager = () => {
                 <table className={`table table-hover mb-0 ${t.table}`} style={{ tableLayout: 'fixed' }}>
                     <thead>
                         <tr>
-                            <th scope="col">User</th>
+                            <th scope="col" style={{ width: '35%' }}>User</th>
                             <th scope="col" style={{ width: '30%' }}>Roles</th>
-                            <th scope="col" style={{ width: '20%' }} className={t.actionCol}>Actions</th>
+                            <th scope="col" style={{ width: '35%' }} className={t.actionCol}>Actions</th>
                         </tr>
                     </thead>
                     <tbody>
                         {filteredUsers.map((user) => (
                             <tr key={user.id}>
-                                <td>
-                                    <div className="fw-bold">{user.name}</div>
-                                    <div className="text-muted small">{user.email}</div>
+                                <td style={{ overflow: 'hidden' }}>
+                                    <div className="fw-bold text-truncate">{user.name}</div>
+                                    <div className="text-muted small text-truncate">{user.email}</div>
                                 </td>
                                 <td>
-                                    <span className={`${styles.roleBadge} ${styles.roleBadgePrimary}`}>
-                                        {(user.defaultRole || user.role).toUpperCase()}
-                                    </span>
-                                    {user.userRoles && user.userRoles.map(r => (
-                                        <span key={r} className={styles.roleBadge}>
-                                            {r.toUpperCase()}
+                                    <div className="d-flex flex-column flex-sm-row flex-wrap align-items-start gap-1">
+                                        <span className={`${styles.roleBadge} ${styles.roleBadgePrimary}`}>
+                                            {(user.defaultRole || user.role).toUpperCase()}
                                         </span>
-                                    ))}
+                                        {user.userRoles && user.userRoles.map(r => (
+                                            <span key={r} className={styles.roleBadge}>
+                                                {r.toUpperCase()}
+                                            </span>
+                                        ))}
+                                    </div>
                                 </td>
                                 <td className={t.actionCol}>
                                     <div className={t.actionGroup}>

--- a/src/components/calendar/CalendarContent.jsx
+++ b/src/components/calendar/CalendarContent.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Calendar, dateFnsLocalizer, Views } from 'react-big-calendar';
 import { format, parse, startOfWeek, getDay, addDays } from 'date-fns';
 import enAU from 'date-fns/locale/en-AU';
@@ -73,6 +73,15 @@ const CalendarContent = () => {
 
     // track the calendar's displayed date to keep it in sync with the data provider
     const [calendarDate, setCalendarDate] = useState(() => calendarDateRange.start);
+    const [calendarView, setCalendarView] = useState(() =>
+        window.innerWidth < 768 ? Views.DAY : Views.WEEK
+    );
+
+    useEffect(() => {
+        if (device === 'mobile') {                                                                           
+            setCalendarView(Views.DAY);                                                                        
+        }
+    }, [device])
 
     /* ----------------------------------------------------------- */
     /* Events and Availabilities - Pre-filtered by CalendarUIContextProvider */
@@ -396,9 +405,7 @@ const CalendarContent = () => {
         />
     );
 
-    // render different views depending on device
-    const defaultView = device === 'mobile' ? Views.DAY : Views.WEEK;
-    const rbcViews = device === 'mobile' ? [Views.DAY, Views.WEEK] : [Views.DAY, Views.WEEK, Views.MONTH];
+    const rbcViews = window.innerWidth < 768 ? [Views.DAY, Views.WEEK] : [Views.DAY, Views.WEEK, Views.MONTH];
 
     return (
         <div className="d-flex h-100 w-100">
@@ -416,7 +423,8 @@ const CalendarContent = () => {
 
                         date={calendarDate}
                         onNavigate={handleNavigate}
-                        defaultView={defaultView}
+                        view={calendarView}
+                        onView={setCalendarView}
                         views={rbcViews}
 
                         draggableAccessor={canDragEvent}

--- a/src/components/calendar/CalendarContent.jsx
+++ b/src/components/calendar/CalendarContent.jsx
@@ -73,15 +73,13 @@ const CalendarContent = () => {
 
     // track the calendar's displayed date to keep it in sync with the data provider
     const [calendarDate, setCalendarDate] = useState(() => calendarDateRange.start);
-    const [calendarView, setCalendarView] = useState(() =>
-        window.innerWidth < 768 ? Views.DAY : Views.WEEK
-    );
+    const [calendarView, setCalendarView] = useState(Views.WEEK);
 
     useEffect(() => {
         if (device === 'mobile') {                                                                           
             setCalendarView(Views.DAY);                                                                        
         }
-    }, [device])
+    }, [device]);
 
     /* ----------------------------------------------------------- */
     /* Events and Availabilities - Pre-filtered by CalendarUIContextProvider */
@@ -405,7 +403,7 @@ const CalendarContent = () => {
         />
     );
 
-    const rbcViews = window.innerWidth < 768 ? [Views.DAY, Views.WEEK] : [Views.DAY, Views.WEEK, Views.MONTH];
+    const rbcViews = device === 'mobile' ? [Views.DAY, Views.WEEK] : [Views.DAY, Views.WEEK, Views.MONTH];
 
     return (
         <div className="d-flex h-100 w-100">

--- a/src/styles/filterPanel.module.css
+++ b/src/styles/filterPanel.module.css
@@ -83,6 +83,13 @@
     width: 0;
 }
 
+@media (max-width: 767px) {
+    .filterPanelContainer.open {
+        width: 0;
+        overflow: hidden;
+    }
+}
+
 /* Section label above toggle rows */
 .filterSectionLabel {
     font-size: 0.6875rem;

--- a/src/styles/manageTable.module.css
+++ b/src/styles/manageTable.module.css
@@ -28,6 +28,7 @@
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    overflow-x: auto;
     scrollbar-gutter: stable;
 }
 
@@ -60,17 +61,31 @@
     border-bottom: none;
 }
 
-/* white-space: nowrap prevents button text wrapping in action cells */
 .actionCol {
     white-space: nowrap;
 }
 
+@media (max-width: 575px) {
+    .actionCol {
+        white-space: normal;
+        width: auto !important;
+    }
+}
+
 .actionGroup {
     display: flex;
+    flex-direction: column;
     gap: 0.375rem;
-    justify-content: flex-end;
-    align-items: center;
-    flex-wrap: nowrap;
+    align-items: flex-end;
+}
+
+@media (min-width: 576px) {
+    .actionGroup {
+        flex-direction: row;
+        justify-content: flex-end;
+        align-items: center;
+        flex-wrap: wrap;
+    }
 }
 
 /* ── Expandable panel ────────────────────────────────────────────── */


### PR DESCRIPTION
  - Stack action buttons vertically on mobile, switch to row on sm+                                                       
  - Stack role badges vertically on mobile, switch to row on sm+
  - Pin User column to 35%, expand Actions to 35% to prevent cramping                                                     
  - Truncate long names and emails instead of pushing columns out                                                         
  - Allow action column to reflow on narrow viewports (remove forced nowrap)                                              
  - Add overflow-x: auto to table wrapper as safety net   