### PR TITLE
feat: completed hours admin stat

### DIFF
--- a/src/components/DashboardOverview.jsx
+++ b/src/components/DashboardOverview.jsx
@@ -60,6 +60,9 @@ const DashboardOverview = () => {
         let tutoringHours = 0;
         let coachingHours = 0;
         let workHours = 0;
+        let completedTutoringHours = 0;
+        let completedCoachingHours = 0;
+        let completedWorkHours = 0;
         let needsConfirmation = 0;
         const uniqueStudentEmails = new Set();
         const uniqueTutorEmailsToday = new Set();
@@ -105,6 +108,17 @@ const DashboardOverview = () => {
                 workHours += hours;
             } else {
                 tutoringHours += hours;
+            }
+
+            // 4b. Completed hours (any shift marked as completed)
+            if (event.workStatus === 'completed') {
+                if (event.workType === 'coaching') {
+                    completedCoachingHours += hours;
+                } else if (event.workType === 'work') {
+                    completedWorkHours += hours;
+                } else {
+                    completedTutoringHours += hours;
+                }
             }
 
             // 5. Unique Students (for Tutor View)
@@ -187,6 +201,11 @@ const DashboardOverview = () => {
                 tutoring: Math.round(tutoringHours * 10) / 10,
                 coaching: Math.round(coachingHours * 10) / 10,
                 work: Math.round(workHours * 10) / 10,
+            },
+            completedHours: {
+                tutoring: Math.round(completedTutoringHours * 10) / 10,
+                coaching: Math.round(completedCoachingHours * 10) / 10,
+                work: Math.round(completedWorkHours * 10) / 10,
             },
             completedShifts,
             uncompletedShifts,

--- a/src/components/dashboard/DashboardAdminStats.jsx
+++ b/src/components/dashboard/DashboardAdminStats.jsx
@@ -1,6 +1,8 @@
-import { FiCalendar, FiUsers, FiActivity } from '@/components/icons';
+import { FiCalendar, FiUsers, FiActivity, FiCheckCircle } from '@/components/icons';
 import BaseStatsCard from './cards/BaseStatsCard';
 import PendingApprovalsCard from './cards/PendingApprovalsCard';
+
+const ADMIN_COL = 'col-12 col-sm-6 col-lg';
 
 const DashboardAdminStats = ({ data, onUpdate }) => (
     <>
@@ -10,11 +12,13 @@ const DashboardAdminStats = ({ data, onUpdate }) => (
             title="Upcoming Events"
             value={data.upcomingEventsCount}
             delay={50}
+            colClass={ADMIN_COL}
         />
         <PendingApprovalsCard
             count={data.unapprovedStudentRequests}
             pendingRequests={data.pendingRequestsData}
             onUpdate={onUpdate}
+            colClass={ADMIN_COL}
         />
         <BaseStatsCard
             icon={FiUsers}
@@ -22,6 +26,7 @@ const DashboardAdminStats = ({ data, onUpdate }) => (
             title="Tutors In Today"
             value={data.tutorsScheduledToday}
             delay={200}
+            colClass={ADMIN_COL}
         />
         <BaseStatsCard
             icon={FiActivity}
@@ -30,6 +35,16 @@ const DashboardAdminStats = ({ data, onUpdate }) => (
             value={(data.weeklyHours.tutoring + data.weeklyHours.coaching + data.weeklyHours.work).toFixed(1)}
             subtitle={`T: ${data.weeklyHours.tutoring} | C: ${data.weeklyHours.coaching} | W: ${data.weeklyHours.work}`}
             delay={250}
+            colClass={ADMIN_COL}
+        />
+        <BaseStatsCard
+            icon={FiCheckCircle}
+            iconBgColor="bg-success"
+            title="Completed Hours"
+            value={(data.completedHours.tutoring + data.completedHours.coaching + data.completedHours.work).toFixed(1)}
+            subtitle={`T: ${data.completedHours.tutoring} | C: ${data.completedHours.coaching} | W: ${data.completedHours.work}`}
+            delay={350}
+            colClass={ADMIN_COL}
         />
     </>
 );

--- a/src/components/dashboard/DashboardStatsCards.jsx
+++ b/src/components/dashboard/DashboardStatsCards.jsx
@@ -5,7 +5,7 @@ import DashboardTutorStats from './DashboardTutorStats';
 import DashboardStudentStats from './DashboardStudentStats';
 
 const DashboardStatsCards = ({ userRole, data, onUpdate }) => (
-    <div className="row g-4 mb-4">
+    <div className="row g-4 mb-4 align-items-stretch">
         {userRole === 'admin' && <DashboardAdminStats data={data} onUpdate={onUpdate} />}
         {userRole === 'teacher' && <DashboardTeacherStats data={data} />}
         {userRole === 'tutor' && <DashboardTutorStats data={data} />}

--- a/src/components/dashboard/cards/BaseStatsCard.jsx
+++ b/src/components/dashboard/cards/BaseStatsCard.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 
-const BaseStatsCard = ({ icon: Icon, iconBgColor, title, value, subtitle, delay = 0 }) => {
+const BaseStatsCard = ({ icon: Icon, iconBgColor, title, value, subtitle, delay = 0, colClass = 'col-12 col-md-4 col-lg-3' }) => {
     const cardRef = useRef(null);
 
     useEffect(() => {
@@ -13,9 +13,9 @@ const BaseStatsCard = ({ icon: Icon, iconBgColor, title, value, subtitle, delay 
     }, [delay]);
 
     return (
-        <div className="col-12 col-md-4 col-lg-3">
-            <div ref={cardRef} className="card border-0 shadow-sm fade">
-                <div className="card-body">
+        <div className={colClass}>
+            <div ref={cardRef} className="card border-0 shadow-sm fade h-100">
+                <div className="card-body d-flex align-items-center">
                     <div className="d-flex align-items-center">
                         <div className="flex-shrink-0">
                             <div className={`${iconBgColor} bg-opacity-10 rounded p-3`}>

--- a/src/components/dashboard/cards/PendingApprovalsCard.jsx
+++ b/src/components/dashboard/cards/PendingApprovalsCard.jsx
@@ -3,7 +3,7 @@ import { FiClock, FiChevronDown } from '@/components/icons';
 import { useApprovalHandlers } from '@/hooks/useApprovalHandlers';
 import PendingApprovalItem from './PendingApprovalItem';
 
-const PendingApprovalsCard = ({ count, pendingRequests, onUpdate, readOnly = false }) => {
+const PendingApprovalsCard = ({ count, pendingRequests, onUpdate, readOnly = false, colClass = 'col-12 col-md-4 col-lg-3' }) => {
     const [isOpen, setIsOpen] = useState(false);
     const dropdownRef = useRef(null);
     const cardRef = useRef(null);
@@ -37,16 +37,16 @@ const PendingApprovalsCard = ({ count, pendingRequests, onUpdate, readOnly = fal
     }, [isOpen]);
 
     return (
-        <div ref={cardRef} className="col-12 col-md-4 col-lg-3 fade">
-            <div ref={dropdownRef} className="position-relative">
+        <div ref={cardRef} className={`${colClass} fade`}>
+            <div ref={dropdownRef} className="position-relative h-100">
                 <div
-                    className="card border-0 shadow-sm"
+                    className="card border-0 shadow-sm h-100"
                     role="button"
                     onClick={() => setIsOpen(!isOpen)}
                     aria-expanded={isOpen}
                 >
-                    <div className="card-body">
-                        <div className="d-flex align-items-center">
+                    <div className="card-body d-flex align-items-center">
+                        <div className="d-flex align-items-center w-100">
                             <div className="flex-shrink-0">
                                 <div className="bg-warning bg-opacity-10 rounded p-3">
                                     <FiClock className="text-warning" size={24} />


### PR DESCRIPTION
- Adds Completed Hours card to admin dashboard (admin-only)
- All 5 admin cards share the same row and height
- `BaseStatsCard` and `PendingApprovalsCard` accept optional `colClass` prop for per-role column sizing