### PR TITLE
fix: subtract break hour from total time displayed in timesheets

### DIFF
--- a/src/app/api/timesheet/route.js
+++ b/src/app/api/timesheet/route.js
@@ -197,7 +197,7 @@ const generateTimeSheet = async (timesheetType, tutorEmail, tutorName, startDate
         templateData[`${key}Finished`] = finished;
         templateData[`${key}Break`] = breakHours;
 
-        templateData[`${key}Total`] = data ? data.hoursForThisDay.toFixed(2) : '';
+        templateData[`${key}Total`] = data ? data.hoursForThisDay.toFixed(2) - breakHours : ''; 
     }
 
     const buffer = renderDocx(fileData, templateData);


### PR DESCRIPTION
This pull request makes a small adjustment to the calculation of total hours in the timesheet generation logic. Now, the value for each day's total hours subtracts break hours from the formatted hours for that day, ensuring the total reflects actual working time.