### PR TITLE
prefill shift participants from tutor filter

### DIFF
--- a/src/components/calendar/CalendarRenderModals.jsx
+++ b/src/components/calendar/CalendarRenderModals.jsx
@@ -3,11 +3,17 @@
 import React, { useMemo, useEffect } from 'react';
 import useModalActionStrategy from '@/hooks/useModalActionStrategy';
 import useAuthSession from '@/hooks/useAuthSession';
+import { useCalendarUI } from '@/contexts/CalendarUIContext';
+import { useAppData } from '@/contexts/AppDataContext';
+import { CalendarFlow } from '@lib/patterns/calendarStrategy';
+import { buildPrefilledStaffFromTutorFilter } from '@/utils/calendarStaffPrefill';
 
 const CalendarRenderModals = ({ calendarAction, calendarTarget, updateCalendarTarget, onClose }) => {
     const modalActionStrategy = useModalActionStrategy(calendarAction);
     const { session, userRole, userRoles } = useAuthSession();
     const userEmail = session.user.email;
+    const { filters } = useCalendarUI();
+    const { tutors, calendarAvailabilities } = useAppData();
 
     // memoise the modal data so it doesn't recreate on every render
     const modalData = useMemo(() => {
@@ -26,11 +32,32 @@ const CalendarRenderModals = ({ calendarAction, calendarTarget, updateCalendarTa
             return calendarTarget;
         }
 
+        const prefilledStaff =
+            calendarAction === CalendarFlow.CREATE_SHIFT
+                ? buildPrefilledStaffFromTutorFilter(
+                      filters.filterByTutor,
+                      tutors,
+                      calendarAvailabilities,
+                      calendarTarget.start,
+                      calendarTarget.end,
+                      'work',
+                  )
+                : undefined;
+
         return createDraft({
             ...calendarTarget,
-            userEmail: userEmail
+            userEmail: userEmail,
+            ...(prefilledStaff?.length ? { prefilledStaff } : {}),
         });
-    }, [modalActionStrategy, calendarTarget, userEmail]);
+    }, [
+        modalActionStrategy,
+        calendarTarget,
+        userEmail,
+        calendarAction,
+        filters.filterByTutor,
+        tutors,
+        calendarAvailabilities,
+    ]);
 
     // sync draft data back to calendarTarget when first created
     // this ensures subsequent updates preserve the entityType and prevent re-creating the draft

--- a/src/firestore/firestoreAdmin.js
+++ b/src/firestore/firestoreAdmin.js
@@ -9,9 +9,10 @@ if (process.env.NODE_ENV === 'development') {
 // initialise Firebase Admin SDK
 if (!admin.apps.length) {
     if (!process.env.FIREBASE_SERVICE_ACCOUNT_KEY) {
-        // No credentials — init with project ID only (emulator handles auth)
+        // Emulator mode — no real credentials needed
+        console.log('FIREBASE_SERVICE_ACCOUNT_KEY is not set. Initialising Firebase Admin against local emulators.');
         admin.initializeApp({
-            projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'demo-talloc',
+            projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID || 'demo-no-project',
         });
     } else {
         const serviceAccount = JSON.parse(

--- a/src/hooks/useModalActionStrategy.js
+++ b/src/hooks/useModalActionStrategy.js
@@ -12,14 +12,14 @@ const MODAL_ACTION_STRATEGY = {
         mode: 'create',
         dataProp: 'newEvent',
 
-        createDraft: ({ start, end, userEmail }) => ({
+        createDraft: ({ start, end, userEmail, prefilledStaff }) => ({
             entityType: CalendarEntityType.SHIFT,
             start,
             end,
 
             title: '',
             description: '',
-            staff: [],
+            staff: prefilledStaff?.length ? prefilledStaff : [],
             classes: [],
             students: [],
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -12,10 +12,12 @@ const MAINTENANCE_MODE = false;
 export async function middleware(req) {
 
     const { pathname } = req.nextUrl;
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV !== 'development') {
         try {
             const rateLimitResponse = await implementRateLimiterWrapper(req, pathname);
-            if (rateLimitResponse) return rateLimitResponse;
+            if (rateLimitResponse) {
+                return rateLimitResponse;
+            }
         } catch (err) {
             console.error('Rate limiter error:', err);
         }

--- a/src/utils/calendarStaffPrefill.js
+++ b/src/utils/calendarStaffPrefill.js
@@ -1,0 +1,51 @@
+/**
+ * Builds EventForm staff option objects from the calendar tutor filter (react-select tags),
+ * matching shape and availability logic from useEventFormData.
+ *
+ * @param {Array<{ value: string, label?: string }>|null|undefined} filterByTutor
+ * @param {Array<{ email: string, name?: string, roles?: string[] }>} tutors
+ * @param {Array<{ tutor: string, start: unknown, end: unknown, locationType?: string }>} calendarAvailabilities
+ * @param {Date|string|number} start
+ * @param {Date|string|number} end
+ * @param {string} [workType='work']
+ * @returns {Array<{ value: string, label: string, roles?: string[], locationType: string }>}
+ */
+export function buildPrefilledStaffFromTutorFilter(
+    filterByTutor,
+    tutors,
+    calendarAvailabilities,
+    start,
+    end,
+    workType = 'work',
+) {
+    if (!filterByTutor?.length) return [];
+
+    const eventStart = new Date(start);
+    const eventEnd = new Date(end);
+    const tutorByEmail = new Map((tutors || []).map((t) => [t.email, t]));
+
+    const result = [];
+    for (const opt of filterByTutor) {
+        const email = opt.value;
+        const tutor = tutorByEmail.get(email);
+        if (workType === 'tutoring' && tutor && !tutor.roles?.includes('tutor')) continue;
+        if (workType === 'coaching' && tutor && !tutor.roles?.includes('coach')) continue;
+
+        const matchingAvailability = (calendarAvailabilities || []).find(
+            (avail) =>
+                avail.tutor === email &&
+                new Date(avail.start) <= eventStart &&
+                new Date(avail.end) >= eventEnd,
+        );
+
+        result.push({
+            value: email,
+            label: tutor?.name ?? opt.label ?? email,
+            roles: tutor?.roles,
+            locationType: matchingAvailability
+                ? matchingAvailability.locationType || 'onsite'
+                : 'unavailable',
+        });
+    }
+    return result;
+}


### PR DESCRIPTION
Prefills new shift participants from selected tutor filter tags when opening the create-shift modal, keeping participant objects aligned with EventForm option shape. Also includes the middleware/firestore updates already committed on this branch.