### PR TITLE
Fix prod reference data auth sync

### DIFF
--- a/src/components/calendar/CustomTimeslot.jsx
+++ b/src/components/calendar/CustomTimeslot.jsx
@@ -10,11 +10,23 @@ const computeAvailabilityHeatColor = (slotTutorCount, weeklyTutorCapacity) => {
     return `rgba(144, 238, 144, ${opacity})`;
 };
 
-const getInitialsFromName = (name) => {
-    if (!name) {
-        return "??"
+const normaliseEmail = (email) => (typeof email === 'string' ? email.toLowerCase() : '');
+
+export const getInitialsFromTutor = (name, email) => {
+    const source = name || email;
+    if (!source) return '';
+
+    const localPart = source.includes('@') ? source.split('@')[0] : source;
+    const parts = localPart
+        .trim()
+        .split(/[\s._-]+/)
+        .filter(Boolean);
+
+    if (parts.length > 1) {
+        return parts.map(w => w[0]).join('').toUpperCase();
     }
-    return name.split(' ').map(w => w[0]).join('').toUpperCase();
+
+    return localPart.substring(0, 2).toUpperCase();
 };
 
 const CustomTimeslot = ({
@@ -32,7 +44,7 @@ const CustomTimeslot = ({
     const tutorNameMap = useMemo(() => {
         const map = {};
         for (const t of slotTutors) {
-            map[t.email] = t.name;
+            map[normaliseEmail(t.email)] = t.name;
         }
         return map;
     }, [slotTutors]);
@@ -76,12 +88,13 @@ const CustomTimeslot = ({
                 availabilityEndTime >= slotEndTime;
 
             if (fullyCoversSlot) {
-                const name = tutorNameMap[availability.tutor];
-                tutorInitialsCoveringThisSlot.push(getInitialsFromName(name));
+                const tutorEmail = availability.tutor;
+                const name = tutorNameMap[normaliseEmail(tutorEmail)];
+                tutorInitialsCoveringThisSlot.push(getInitialsFromTutor(name, tutorEmail));
             }
         }
 
-        return Array.from(new Set(tutorInitialsCoveringThisSlot)).sort();
+        return Array.from(new Set(tutorInitialsCoveringThisSlot.filter(Boolean))).sort();
     }, [availabilitiesRelevantToSlot, slotStartTime, slotEndTime, tutorNameMap]);
 
     /* --------------------------------------------------------- */

--- a/src/contexts/AppDataContext.jsx
+++ b/src/contexts/AppDataContext.jsx
@@ -32,6 +32,15 @@ export const useAppData = () => {
     return context;
 };
 
+const fetchReferenceDataSafely = async (label, fetchFn, fallback) => {
+    try {
+        return await fetchFn();
+    } catch (error) {
+        console.error(`Error loading ${label}:`, error);
+        return fallback;
+    }
+};
+
 /**
  * AppDataContextProvider
  *
@@ -123,9 +132,11 @@ export const AppDataContextProvider = ({ children }) => {
         if (!userEmail) return;
         const loadReferenceData = async () => {
             const [tutorList, classList, subjectList] = await Promise.all([
-                fetchCacheTutors(),
-                canReadCanvasReferenceData ? fetchCacheClasses() : Promise.resolve([]),
-                fetchCacheSubjects(),
+                fetchReferenceDataSafely('tutors', fetchCacheTutors, []),
+                canReadCanvasReferenceData
+                    ? fetchReferenceDataSafely('classes', fetchCacheClasses, [])
+                    : Promise.resolve([]),
+                fetchReferenceDataSafely('subjects', fetchCacheSubjects, []),
             ]);
             setTutors(tutorList);
             setClasses(classList);
@@ -133,14 +144,18 @@ export const AppDataContextProvider = ({ children }) => {
 
             // Canvas users include roster data and are only needed by staff who manage classes.
             if (canReadCanvasReferenceData) {
-                const studentList = await fetchCacheStudents();
+                const studentList = await fetchReferenceDataSafely('students', fetchCacheStudents, []);
                 setStudents(studentList);
             } else {
                 setStudents([]);
             }
 
             if (userRole === 'student') {
-                const eligibility = await fetchStudentTutorEligibility(userEmail);
+                const eligibility = await fetchReferenceDataSafely(
+                    'student tutor eligibility',
+                    () => fetchStudentTutorEligibility(userEmail),
+                    { coverageKeys: [], eligibleTutorEmails: [], eligibleTutors: [] }
+                );
                 setStudentTutorEligibility(eligibility);
             } else {
                 setStudentTutorEligibility({ coverageKeys: [], eligibleTutorEmails: [], eligibleTutors: [] });

--- a/src/lib/security/clientAuth.js
+++ b/src/lib/security/clientAuth.js
@@ -61,13 +61,9 @@ export const fbAuthLoginSync = async (token) => {
         return;
     }
 
-    // if Firebase already has a live session fetch - groken ID token from browser. else, re-authenticate. 
+    // Always consume the fresh custom token so Firestore rules see current role claims.
     try {
-        if (clientAuth.currentUser) {
-            await clientAuth.currentUser.getIdToken(true);
-        } else {
-            await signInWithCustomToken(clientAuth, token);
-        }
+        await signInWithCustomToken(clientAuth, token);
     } catch (error) {
         console.error("Firebase Sync Error:", error);
     }

--- a/tests/unit/CustomTimeslot.test.jsx
+++ b/tests/unit/CustomTimeslot.test.jsx
@@ -1,0 +1,12 @@
+import { getInitialsFromTutor } from '@/components/calendar/CustomTimeslot.jsx';
+
+describe('CustomTimeslot', () => {
+    test('uses tutor names when available', () => {
+        expect(getInitialsFromTutor('Viraj Patel', 'tutor@kings.edu.au')).toBe('VP');
+    });
+
+    test('falls back to tutor email when reference data is missing', () => {
+        expect(getInitialsFromTutor('', 'tutor@kings.edu.au')).toBe('TU');
+        expect(getInitialsFromTutor(undefined, 'alex.chen@kings.edu.au')).toBe('AC');
+    });
+});

--- a/tests/unit/clientAuth.test.js
+++ b/tests/unit/clientAuth.test.js
@@ -1,0 +1,35 @@
+import { signInWithCustomToken } from 'firebase/auth';
+import { auth } from '@/firestore/firestoreClient';
+import { fbAuthLoginSync } from '@/lib/security/clientAuth';
+
+jest.mock('firebase/auth', () => ({
+    signInWithCustomToken: jest.fn(),
+    signOut: jest.fn(),
+}));
+
+jest.mock('@/firestore/firestoreClient', () => ({
+    auth: {
+        currentUser: {
+            getIdToken: jest.fn(),
+        },
+    },
+}));
+
+describe('clientAuth', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('signs in with the fresh custom token even when a Firebase user already exists', async () => {
+        await fbAuthLoginSync('fresh-token');
+
+        expect(signInWithCustomToken).toHaveBeenCalledWith(auth, 'fresh-token');
+        expect(auth.currentUser.getIdToken).not.toHaveBeenCalled();
+    });
+
+    test('does not sign in when no token is provided', async () => {
+        await fbAuthLoginSync('');
+
+        expect(signInWithCustomToken).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- Re-authenticate Firebase with the fresh custom token so Firestore rules receive current role claims
- Isolate reference-data fetch failures so a denied Canvas read does not block tutor data from loading
- Fall back availability initials to tutor email initials instead of showing ??

## Tests
- npx jest tests/unit/clientAuth.test.js tests/unit/CustomEvent.test.jsx tests/unit/CustomTimeslot.test.jsx --runInBand
- npm run lint
- npm run test -- --runInBand
- npm run build