### PR TITLE
Fix Canvas reference data permissions

### DIFF
--- a/src/app/api/canvas/reference/classes/route.js
+++ b/src/app/api/canvas/reference/classes/route.js
@@ -1,0 +1,9 @@
+import { listCanvasClasses } from '@/lib/canvas/canvasReferenceData';
+import { getRequiredAdminOrTeacherSession } from '@/lib/security/serverAuth';
+
+export async function GET() {
+    const { error } = await getRequiredAdminOrTeacherSession();
+    if (error) return error;
+
+    return Response.json(await listCanvasClasses());
+}

--- a/src/app/api/canvas/reference/courses/route.js
+++ b/src/app/api/canvas/reference/courses/route.js
@@ -1,0 +1,9 @@
+import { listCanvasCourses } from '@/lib/canvas/canvasReferenceData';
+import { getRequiredAdminOrTeacherSession } from '@/lib/security/serverAuth';
+
+export async function GET() {
+    const { error } = await getRequiredAdminOrTeacherSession();
+    if (error) return error;
+
+    return Response.json(await listCanvasCourses());
+}

--- a/src/app/api/canvas/reference/students/route.js
+++ b/src/app/api/canvas/reference/students/route.js
@@ -1,0 +1,9 @@
+import { listCanvasStudents } from '@/lib/canvas/canvasReferenceData';
+import { getRequiredAdminOrTeacherSession } from '@/lib/security/serverAuth';
+
+export async function GET() {
+    const { error } = await getRequiredAdminOrTeacherSession();
+    if (error) return error;
+
+    return Response.json(await listCanvasStudents());
+}

--- a/src/components/UserRolesManager.jsx
+++ b/src/components/UserRolesManager.jsx
@@ -74,8 +74,11 @@ const UserRolesManager = () => {
         fetchUsers();
 
         const fetchCanvasCourses = async () => {
-            const querySnapshot = await getDocs(collection(db, 'canvasCourses'));
-            setCanvasCourses(querySnapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+            const response = await fetch('/api/canvas/reference/courses');
+            if (!response.ok) {
+                throw new Error(`Request failed with status ${response.status}`);
+            }
+            setCanvasCourses(await response.json());
         };
 
         fetchCanvasCourses().catch((error) => {

--- a/src/firestore/firestoreFetch.js
+++ b/src/firestore/firestoreFetch.js
@@ -20,6 +20,14 @@ const getCachedOrFetch = async (key, fetchFn) => {
     return data;
 };
 
+const fetchJson = async (url) => {
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+    }
+    return response.json();
+};
+
 const deserializeShift = (doc) => {
     const data = doc.data();
     return {
@@ -208,71 +216,10 @@ export const fetchCacheSubjects = () =>
     getCachedOrFetch('subjects', async () => []);
 
 export const fetchCacheClasses = () =>
-    getCachedOrFetch('classes', async () => {
-        const [coursesSnapshot, enrollmentsSnapshot] = await Promise.all([
-            getDocs(collection(db, 'canvasCourses')),
-            getDocs(collection(db, 'canvasEnrollments')),
-        ]);
-
-        const studentsByCourse = new Map();
-        enrollmentsSnapshot.docs.forEach((docSnap) => {
-            const data = docSnap.data();
-            const courseId = String(data.courseId || '');
-            if (!courseId) return;
-            const students = studentsByCourse.get(courseId) || [];
-            students.push({
-                id: data.userId,
-                canvasUserId: data.userId,
-                enrollmentId: docSnap.id,
-                email: data.email || data.emailLower || '',
-                name: data.userName || data.email || data.emailLower || '',
-                sortableName: data.sortableName || '',
-                enrollmentState: data.enrollmentState || '',
-                lastActivityAt: data.lastActivityAt || null,
-                currentScore: data.currentScore ?? null,
-                currentGrade: data.currentGrade || null,
-                finalScore: data.finalScore ?? null,
-                finalGrade: data.finalGrade || null,
-            });
-            studentsByCourse.set(courseId, students);
-        });
-
-        return coursesSnapshot.docs.map((docSnap) => {
-            const data = docSnap.data();
-            return {
-                id: docSnap.id,
-                name: data.name || '',
-                courseCode: data.courseCode || '',
-                workflowState: data.workflowState || '',
-                termId: data.termId ?? null,
-                termName: data.termName || '',
-                termStartAt: data.termStartAt || null,
-                termEndAt: data.termEndAt || null,
-                syncedAt: data.syncedAt || null,
-                rosterSyncedAt: data.rosterSyncedAt || null,
-                blueprintCourseId: data.blueprintCourseId || null,
-                blueprintCourseName: data.blueprintCourseName || null,
-                blueprintCourseCode: data.blueprintCourseCode || null,
-                students: studentsByCourse.get(docSnap.id) || [],
-            };
-        });
-    });
+    getCachedOrFetch('classes', () => fetchJson('/api/canvas/reference/classes'));
 
 export const fetchCacheStudents = () =>
-    getCachedOrFetch('students', async () => {
-        const snapshot = await getDocs(collection(db, 'canvasUsers'));
-        return snapshot.docs.map((doc) => {
-            const { email, name, sortableName, sisId } = doc.data();
-            return {
-                id: doc.id,
-                canvasUserId: doc.id,
-                email,
-                name: name || email,
-                sortableName,
-                sisId,
-            };
-        });
-    });
+    getCachedOrFetch('students', () => fetchJson('/api/canvas/reference/students'));
 
 export const fetchStudentTutorEligibility = async (studentEmail) => {
     if (!studentEmail) {

--- a/src/lib/canvas/canvasReferenceData.js
+++ b/src/lib/canvas/canvasReferenceData.js
@@ -1,0 +1,91 @@
+import 'server-only';
+
+import { adminDb } from '@/firestore/firestoreAdmin';
+
+const serializeTimestamp = (value) => {
+    if (!value) return null;
+    if (value.toDate) return value.toDate().toISOString();
+    if (value instanceof Date) return value.toISOString();
+    return value;
+};
+
+const sortByName = (a, b) => (a.name || '').localeCompare(b.name || '');
+
+const mapCanvasCourse = (docSnap) => {
+    const data = docSnap.data();
+    return {
+        id: docSnap.id,
+        name: data.name || '',
+        courseCode: data.courseCode || '',
+        workflowState: data.workflowState || '',
+        termId: data.termId ?? null,
+        termName: data.termName || '',
+        termStartAt: data.termStartAt || null,
+        termEndAt: data.termEndAt || null,
+        syncedAt: serializeTimestamp(data.syncedAt),
+        rosterSyncedAt: serializeTimestamp(data.rosterSyncedAt),
+        blueprintCourseId: data.blueprintCourseId || null,
+        blueprintCourseName: data.blueprintCourseName || null,
+        blueprintCourseCode: data.blueprintCourseCode || null,
+    };
+};
+
+const mapCanvasStudent = (docSnap) => {
+    const { email, name, sortableName, sisId } = docSnap.data();
+    return {
+        id: docSnap.id,
+        canvasUserId: docSnap.id,
+        email,
+        name: name || email,
+        sortableName,
+        sisId,
+    };
+};
+
+export const listCanvasCourses = async () => {
+    const snapshot = await adminDb.collection('canvasCourses').get();
+    return snapshot.docs.map(mapCanvasCourse).sort(sortByName);
+};
+
+export const listCanvasClasses = async () => {
+    const [coursesSnapshot, enrollmentsSnapshot] = await Promise.all([
+        adminDb.collection('canvasCourses').get(),
+        adminDb.collection('canvasEnrollments').get(),
+    ]);
+
+    const studentsByCourse = new Map();
+    enrollmentsSnapshot.docs.forEach((docSnap) => {
+        const data = docSnap.data();
+        const courseId = String(data.courseId || '');
+        if (!courseId) return;
+
+        const students = studentsByCourse.get(courseId) || [];
+        students.push({
+            id: data.userId,
+            canvasUserId: data.userId,
+            enrollmentId: docSnap.id,
+            email: data.email || data.emailLower || '',
+            name: data.userName || data.email || data.emailLower || '',
+            sortableName: data.sortableName || '',
+            enrollmentState: data.enrollmentState || '',
+            lastActivityAt: serializeTimestamp(data.lastActivityAt),
+            currentScore: data.currentScore ?? null,
+            currentGrade: data.currentGrade || null,
+            finalScore: data.finalScore ?? null,
+            finalGrade: data.finalGrade || null,
+        });
+        studentsByCourse.set(courseId, students);
+    });
+
+    return coursesSnapshot.docs
+        .map((docSnap) => ({
+            ...mapCanvasCourse(docSnap),
+            students: studentsByCourse.get(docSnap.id) || [],
+        }))
+        .sort(sortByName);
+};
+
+export const listCanvasStudents = async () => {
+    const snapshot = await adminDb.collection('canvasUsers').get();
+    return snapshot.docs.map(mapCanvasStudent).sort(sortByName);
+};

--- a/tests/firebase/firebase.canvas.test.js
+++ b/tests/firebase/firebase.canvas.test.js
@@ -62,6 +62,21 @@ describe('Firebase Security Rules - Canvas cache collections', () => {
         await assertSucceeds(db.collection('canvasEnrollments').get());
     });
 
+    test('users with secondary admin role can read Canvas cache collections', async () => {
+        await seedCanvasCache();
+
+        const context = testEnv.authenticatedContext('tutor-admin@kings.edu.au', {
+            email: 'tutor-admin@kings.edu.au',
+            defaultRole: 'tutor',
+            userRoles: ['admin'],
+        });
+        const db = context.firestore();
+
+        await assertSucceeds(db.collection('canvasCourses').get());
+        await assertSucceeds(db.collection('canvasUsers').get());
+        await assertSucceeds(db.collection('canvasEnrollments').get());
+    });
+
     test('students cannot read Canvas cache collections', async () => {
         await seedCanvasCache();
 

--- a/tests/unit/canvasReferenceData.test.js
+++ b/tests/unit/canvasReferenceData.test.js
@@ -1,0 +1,121 @@
+jest.mock('server-only', () => ({}), { virtual: true });
+
+const courseDocs = [
+    {
+        id: '202',
+        data: () => ({
+            name: 'Science Year 8',
+            courseCode: 'SCI8',
+            rosterSyncedAt: { toDate: () => new Date('2026-05-18T01:00:00.000Z') },
+        }),
+    },
+    {
+        id: '101',
+        data: () => ({
+            name: 'Mathematics Year 7',
+            courseCode: 'MATH7',
+            blueprintCourseId: '900',
+            blueprintCourseName: 'Blueprint Mathematics',
+            blueprintCourseCode: 'BP_7math',
+        }),
+    },
+];
+
+const enrollmentDocs = [
+    {
+        id: 'enrol-1',
+        data: () => ({
+            courseId: '101',
+            userId: 'u1',
+            email: 'student@kings.edu.au',
+            userName: 'Student One',
+            lastActivityAt: { toDate: () => new Date('2026-05-19T02:00:00.000Z') },
+        }),
+    },
+];
+
+const userDocs = [
+    {
+        id: 'u1',
+        data: () => ({
+            email: 'student@kings.edu.au',
+            name: 'Student One',
+            sortableName: 'One, Student',
+            sisId: 'S1',
+        }),
+    },
+];
+
+const adminDb = {
+    collection: jest.fn((name) => ({
+        get: jest.fn(() => {
+            if (name === 'canvasCourses') return Promise.resolve({ docs: courseDocs });
+            if (name === 'canvasEnrollments') return Promise.resolve({ docs: enrollmentDocs });
+            if (name === 'canvasUsers') return Promise.resolve({ docs: userDocs });
+            return Promise.resolve({ docs: [] });
+        }),
+    })),
+};
+
+jest.mock('@/firestore/firestoreAdmin', () => ({ adminDb }));
+
+const {
+    listCanvasClasses,
+    listCanvasCourses,
+    listCanvasStudents,
+} = require('@/lib/canvas/canvasReferenceData');
+
+describe('canvasReferenceData', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('lists courses in the shape expected by coverage selectors', async () => {
+        await expect(listCanvasCourses()).resolves.toEqual([
+            expect.objectContaining({
+                id: '101',
+                name: 'Mathematics Year 7',
+                courseCode: 'MATH7',
+                blueprintCourseId: '900',
+            }),
+            expect.objectContaining({
+                id: '202',
+                name: 'Science Year 8',
+                rosterSyncedAt: '2026-05-18T01:00:00.000Z',
+            }),
+        ]);
+    });
+
+    test('lists classes with roster details', async () => {
+        await expect(listCanvasClasses()).resolves.toEqual([
+            expect.objectContaining({
+                id: '101',
+                students: [
+                    expect.objectContaining({
+                        id: 'u1',
+                        email: 'student@kings.edu.au',
+                        name: 'Student One',
+                        lastActivityAt: '2026-05-19T02:00:00.000Z',
+                    }),
+                ],
+            }),
+            expect.objectContaining({
+                id: '202',
+                students: [],
+            }),
+        ]);
+    });
+
+    test('lists students in the shape expected by event forms', async () => {
+        await expect(listCanvasStudents()).resolves.toEqual([
+            {
+                id: 'u1',
+                canvasUserId: 'u1',
+                email: 'student@kings.edu.au',
+                name: 'Student One',
+                sortableName: 'One, Student',
+                sisId: 'S1',
+            },
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Serve Canvas courses, classes, and students through admin/teacher authenticated API routes
- Stop client code from reading Canvas cache collections directly with Firestore client rules
- Add mapper tests and a multi-role Canvas rules regression test

## Verification
- `npm test -- --runTestsByPath tests/unit/canvasReferenceData.test.js`
- `FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 npx jest --config=tests/firebase/jest.firebase.config.js --runTestsByPath tests/firebase/firebase.canvas.test.js`
- `npm run lint`
- `npm run build`