### PR TITLE
fix(alerts): stop toast flashing; refactor calendar colours

### DIFF
--- a/src/components/AlertBox.jsx
+++ b/src/components/AlertBox.jsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef } from 'react';
 
+const TOAST_MAX_WIDTH = 360;
+
 /**
  * Notification alert box component for displaying messages
  * - Type: can be either "ERROR", "WARNING", "INFO", or "SUCCESS"
@@ -12,6 +14,11 @@ import { useEffect, useRef } from 'react';
  */
 const AlertBox = ({ message, type, onClose }) => {
     const toastRef = useRef(null);
+    // Keep the latest onClose in a ref so the show/dispose effect doesn't
+    // re-run every time the parent re-creates the callback (which restarts
+    // Bootstrap's fade-in animation — the "flashing" bug).
+    const onCloseRef = useRef(onClose);
+    onCloseRef.current = onClose;
 
     if (!type) {
         throw new Error("AlertBox: 'type' prop is required (ERROR, SUCCESS, or INFO)");
@@ -57,9 +64,7 @@ const AlertBox = ({ message, type, onClose }) => {
                 window.bootstrap.Toast.getOrCreateInstance(toastElement);
 
             const handleHidden = () => {
-                if (onClose) {
-                    onClose();
-                }
+                onCloseRef.current?.();
             };
 
             toastElement.addEventListener('hidden.bs.toast', handleHidden);
@@ -70,7 +75,7 @@ const AlertBox = ({ message, type, onClose }) => {
                 toastBootstrap.dispose();
             };
         }
-    }, [config, onClose]);
+    }, [config]);
 
     if (!config) {
         return null;
@@ -79,17 +84,18 @@ const AlertBox = ({ message, type, onClose }) => {
     return (
         <div
             ref={toastRef}
-            className={`toast align-items-center border-0 mb-2 shadow ${config.textClass || 'text-white'} w-auto ${config.colour}`}
+            className={`toast align-items-center border-0 mb-2 shadow ${config.textClass || 'text-white'} ${config.colour}`}
             role="alert"
             aria-live="assertive"
             aria-atomic="true"
             data-bs-autohide="true"
             data-bs-delay="5000"
+            style={{ maxWidth: TOAST_MAX_WIDTH, width: '100%' }}
         >
             <div className="d-flex">
-                <div className="toast-body d-flex align-items-center flex-grow-1 py-3 px-3">
-                    <i className={`bi ${config.iconClass} me-3 fs-5`}></i>
-                    <span className="fs-6">{message}</span>
+                <div className="toast-body d-flex align-items-center flex-grow-1 py-3 px-3" style={{ minWidth: 0 }}>
+                    <i className={`bi ${config.iconClass} me-3 fs-5 flex-shrink-0`}></i>
+                    <span className="fs-6" style={{ wordBreak: 'break-word', overflowWrap: 'anywhere' }}>{message}</span>
                 </div>
                 <button
                     type="button"

--- a/src/constants/calendarColours.js
+++ b/src/constants/calendarColours.js
@@ -2,23 +2,30 @@
  * Calendar colour constants — must stay in sync with calendarUI.js.
  * Used by CalendarLegend, WelcomeModal, and CalendarHowToModal.
  *
- * Design system:
- *   - Soft tinted backgrounds (50–100 range) keep the calendar calm and scannable.
- *   - Saturated left border acts as the status accent — the eye picks up status
- *     from the border colour, not from a screaming fill.
- *   - Dark text (700–900 range) on every chip for AA+ contrast.
- *   - Hue choices map to intuitive semantics: blue=confirmed, green=done,
- *     amber=waiting, red=problem, slate=neutral, violet=coaching.
+ * Design system ("Warm Saturated", Option 2 from Calendar Redesign v2):
+ *   - HUE encodes TYPE      → indigo=tutoring, plum=coaching, amber=pending,
+ *                             red=denied, warm-stone=not-attended, mint=availability.
+ *   - SOLIDITY encodes STATUS → lighter wash for incomplete/active sessions,
+ *                               richer fill of the same hue once completed,
+ *                               so the eye can pair "tutoring" with "tutoring done"
+ *                               at a glance.
+ *   - TEXT is a single dark colour (#1a1d23) on every chip — consistent text
+ *     reads cleanly across the saturated fills and avoids the black/white mix
+ *     that earlier iterations had.
+ *   - Saturated left border acts as the status accent; soft outer border
+ *     (border colour at 20% alpha) gives the chip a subtle frame.
+ *   - Availability is the calmest hue (mint) with a dotted border so it reads
+ *     as a planning *layer*, not an action item.
  */
 export const CALENDAR_COLOURS = {
-    availabilityHeatmap: { bg: 'rgba(134, 239, 172, 0.45)', border: '#16a34a' },
-    availabilityBlock:   { bg: '#86efac',                  border: '#14532d', text: '#0f172a', borderStyle: 'dotted' },
-    confirmed:           { bg: '#dbeafe',                  border: '#2563eb', text: '#0f172a' },
-    coaching:            { bg: '#e0f2fe',                  border: '#38bdf8', text: '#0f172a' },
-    pending:             { bg: '#fef3c7',                  border: '#d97706', text: '#0f172a' },
-    denied:              { bg: '#fee2e2',                  border: '#dc2626', text: '#0f172a' },
-    completed:           { bg: '#dcfce7',                  border: '#16a34a', text: '#0f172a' },
-    coachingCompleted:   { bg: '#ccfbf1',                  border: '#0d9488', text: '#0f172a' },
-    notAttended:         { bg: '#fafaf9',                  border: '#57534e', text: '#0f172a' },
-    declined:            { bg: '#f1f5f9',                  border: '#64748b', text: '#0f172a' },
+    availabilityHeatmap: { bg: 'rgba(218, 247, 227, 0.55)', border: '#00572e' },
+    availabilityBlock:   { bg: '#daf7e3',                  border: '#00572e', text: '#1a1d23', borderStyle: 'dotted' },
+    confirmed:           { bg: '#a4ccff',                  border: '#0044cc', text: '#1a1d23' },
+    coaching:            { bg: '#e8bbf3',                  border: '#833794', text: '#1a1d23' },
+    pending:             { bg: '#f9d280',                  border: '#ac6900', text: '#1a1d23' },
+    denied:              { bg: '#ffb0b0',                  border: '#ba0022', text: '#1a1d23' },
+    completed:           { bg: '#7daeff',                  border: '#002bb4', text: '#1a1d23' },
+    coachingCompleted:   { bg: '#d398e0',                  border: '#6f0f82', text: '#1a1d23' },
+    notAttended:         { bg: '#eccdbf',                  border: '#8f5a41', text: '#1a1d23' },
+    declined:            { bg: '#e8e9ec',                  border: '#6b7280', text: '#1a1d23' },
 };

--- a/src/contexts/AlertContext.jsx
+++ b/src/contexts/AlertContext.jsx
@@ -1,9 +1,22 @@
 'use client';
 
-import { createContext, useState, useMemo, useCallback, useEffect } from 'react';
+import { createContext, memo, useState, useMemo, useCallback, useEffect } from 'react';
 import AlertBox from '@/components/AlertBox';
 
 export const AlertContext = createContext();
+
+// Wrap AlertBox so each row gets a STABLE onClose bound to its id. Without this,
+// re-rendering the provider (e.g. another alert being added/removed) hands every
+// existing toast a fresh `() => removeAlert(id)` and AlertBox's setup effect
+// tears down and re-shows the Bootstrap toast — the visible "flash".
+const MemoAlert = memo(function MemoAlert({ id, message, type, onClose }) {
+    const handleClose = useCallback(() => onClose(id), [id, onClose]);
+    return (
+        <div style={{ pointerEvents: 'auto', width: '100%' }}>
+            <AlertBox message={message} type={type} onClose={handleClose} />
+        </div>
+    );
+});
 
 /**
  * Custom Alert Provider for alert boxes
@@ -58,28 +71,23 @@ export const AlertContextProvider = ({ children }) => {
         <AlertContext.Provider value={contextValue}>
             {children}
 
-            {/* Alerts stacked in fixed container */}
-            <div className="toast-container position-fixed bottom-0 end-0 p-3">
+            {/* Alerts stacked bottom-right. Constrain the container so a tall
+                stack never reaches the viewport edge — individual toasts set
+                their own max-width (see AlertBox). */}
+            <div
+                className="toast-container position-fixed bottom-0 end-0 p-3 d-flex flex-column align-items-end"
+                style={{ maxWidth: 'min(380px, 90vw)', maxHeight: '100vh', overflowY: 'auto', pointerEvents: 'none' }}
+            >
                 {alerts.map((alert) => (
-                    <AlertBox
+                    <MemoAlert
                         key={alert.id}
+                        id={alert.id}
                         message={alert.message}
                         type={alert.type}
-                        onClose={() => removeAlert(alert.id)}
+                        onClose={removeAlert}
                     />
                 ))}
             </div>
-            {/* <div className="position-fixed bottom-0 end-0 m-4 d-flex flex-column align-items-end gap-2" style={{ zIndex: 9999 }}>
-                {alerts.map((alert) => (
-                    <AlertBox
-                        key={alert.id}
-                        message={alert.message}
-                        setMessage={() => removeAlert(alert.id)}
-                        type={alert.type}
-                        setType={() => {}}
-                    />
-                ))}
-            </div> */}
         </AlertContext.Provider>
     );
 };

--- a/src/styles/customEvent.module.css
+++ b/src/styles/customEvent.module.css
@@ -18,7 +18,7 @@
     font-weight: 600;
     font-size: 0.82rem;
     line-height: 1.35;
-    color: #0f172a;
+    color: #1a1d23;
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -29,7 +29,7 @@
 .staffInitials {
     font-size: 0.7rem;
     font-weight: 500;
-    color: #0f172a;
+    color: #1a1d23;
     margin-top: 2px;
     white-space: nowrap;
     overflow: hidden;

--- a/src/utils/calendarUI.js
+++ b/src/utils/calendarUI.js
@@ -102,7 +102,7 @@ export const calendarUIGetEventStyle = (event, userRole, userEmail) => {
                 ? `2px ${borderStyle} ${borderColor}`
                 : `4px solid ${borderColor}`,
             borderRadius: '4px',
-            boxShadow: isPatterned ? 'none' : '0 1px 2px rgba(15, 23, 42, 0.06)',
+            boxShadow: isPatterned ? 'none' : '0 1px 3px rgba(0, 0, 0, 0.06)',
             fontWeight: 500,
         },
     };


### PR DESCRIPTION
## Summary
- **Toast flash fix**: `AlertBox`'s show/dispose effect depended on a non-stable `onClose`, so adding/removing one toast tore down and re-showed every other toast (the visible "flash"). Latest `onClose` now lives in a ref, and each rendered toast is memoised with a stable per-id close handler.
- **Toast layout**: container is width-constrained and long messages wrap, so oversized alerts no longer push off-screen.
- **Calendar palette**: adopts the "Warm Saturated" option from the calendar redesign — hue encodes session type, solidity encodes status (lighter wash for active, richer fill once completed). Chip text unified to `#1a1d23`; event box-shadow softened to a neutral black tint.

## Test plan
- [ ] Trigger multiple alerts in quick succession — existing toasts stay still (no fade-in restart) when new ones appear or auto-dismiss.
- [ ] Fire an alert with a very long message — toast wraps and stays within the bottom-right container.
- [ ] Open the calendar as both tutor and coach — verify each status (pending, confirmed, completed, denied, not-attended, coaching, coaching-completed, availability) matches the legend.
- [ ] Check `CalendarLegend`, `WelcomeModal`, and `CalendarHowToModal` use the new colours consistently.