### PR TITLE
fix(ui): restore users page scrollbar and lighten incomplete event colours

### DIFF
--- a/src/constants/calendarColours.js
+++ b/src/constants/calendarColours.js
@@ -20,8 +20,8 @@
 export const CALENDAR_COLOURS = {
     availabilityHeatmap: { bg: 'rgba(218, 247, 227, 0.55)', border: '#00572e' },
     availabilityBlock:   { bg: '#daf7e3',                  border: '#00572e', text: '#1a1d23', borderStyle: 'dotted' },
-    confirmed:           { bg: '#a4ccff',                  border: '#0044cc', text: '#1a1d23' },
-    coaching:            { bg: '#e8bbf3',                  border: '#833794', text: '#1a1d23' },
+    confirmed:           { bg: '#cce0ff',                  border: '#0044cc', text: '#1a1d23' },
+    coaching:            { bg: '#f3d6fa',                  border: '#833794', text: '#1a1d23' },
     pending:             { bg: '#f9d280',                  border: '#ac6900', text: '#1a1d23' },
     denied:              { bg: '#ffb0b0',                  border: '#ba0022', text: '#1a1d23' },
     completed:           { bg: '#7daeff',                  border: '#002bb4', text: '#1a1d23' },

--- a/src/styles/manageTable.module.css
+++ b/src/styles/manageTable.module.css
@@ -5,6 +5,7 @@
     background: white;
     border-radius: 0.75rem;
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    height: 100%;
     flex: 1;
     min-height: 0;
     display: flex;


### PR DESCRIPTION
## Summary
- Restore the scrollbar on `/userRoles` (and the other Manage pages that share `manageTable.module.css`) by giving `.container` `height: 100%`. Its parent `.fade-in` is `display: block`, so `flex: 1` alone had nothing to bind against — the container grew with content instead of capping at the viewport, and `.tableWrap`'s `overflow-y: auto` had no reason to scroll.
- Lighten the incomplete tutoring (`confirmed`) and incomplete coaching (`coaching`) fills so they read more clearly as the "active / not yet done" wash, widening the contrast against their richer completed counterparts.

## Test plan
- [ ] Open `/userRoles` with enough users to exceed the viewport — confirm the table scrolls inside the card and the page itself does not scroll.
- [ ] Open `/classes` and `/subjects` — confirm scrolling still works there and nothing else shifted.
- [ ] Open the calendar — confirm incomplete tutoring sessions are visibly lighter than completed ones, and the same holds for coaching.
- [ ] Sanity-check the legend modal still matches the events on the calendar.