### PR TITLE
refactor(calendar): darken both coaching shades a step

### DIFF
--- a/src/constants/calendarColours.js
+++ b/src/constants/calendarColours.js
@@ -21,11 +21,11 @@ export const CALENDAR_COLOURS = {
     availabilityHeatmap: { bg: 'rgba(218, 247, 227, 0.55)', border: '#00572e' },
     availabilityBlock:   { bg: '#daf7e3',                  border: '#00572e', text: '#1a1d23', borderStyle: 'dotted' },
     confirmed:           { bg: '#cce0ff',                  border: '#0044cc', text: '#1a1d23' },
-    coaching:            { bg: '#f3d6fa',                  border: '#833794', text: '#1a1d23' },
+    coaching:            { bg: '#e2b4ee',                  border: '#833794', text: '#1a1d23' },
     pending:             { bg: '#f9d280',                  border: '#ac6900', text: '#1a1d23' },
     denied:              { bg: '#ffb0b0',                  border: '#ba0022', text: '#1a1d23' },
     completed:           { bg: '#7daeff',                  border: '#002bb4', text: '#1a1d23' },
-    coachingCompleted:   { bg: '#d398e0',                  border: '#6f0f82', text: '#1a1d23' },
+    coachingCompleted:   { bg: '#bf7dcf',                  border: '#6f0f82', text: '#1a1d23' },
     notAttended:         { bg: '#eccdbf',                  border: '#8f5a41', text: '#1a1d23' },
     declined:            { bg: '#e8e9ec',                  border: '#6b7280', text: '#1a1d23' },
 };


### PR DESCRIPTION
## Summary
- Bump the coaching pair one step darker so the plum hue reads more confidently against the indigo tutoring chips.
- Preserves the incomplete-vs-completed contrast within the coaching pair — incomplete stays the lighter wash, completed stays the richer fill.

Specifically:
- \`coaching\` (incomplete): \`#f3d6fa\` → \`#e2b4ee\`
- \`coachingCompleted\`: \`#d398e0\` → \`#bf7dcf\`

## Test plan
- [ ] Open the calendar — confirm incomplete coaching sessions are noticeably more saturated than before, but still clearly lighter than completed coaching.
- [ ] Confirm the legend modal matches the on-calendar chips.
- [ ] Sanity-check that tutoring (indigo) and coaching (plum) remain easy to tell apart at a glance.