### PR TITLE
Fix undeletable tutor availabilities that overlap shifts

### DIFF
--- a/src/components/calendar/CalendarContent.jsx
+++ b/src/components/calendar/CalendarContent.jsx
@@ -218,8 +218,22 @@ const CalendarContent = () => {
         const action = strategy.actions.getEventFlow(calEvent);
         if (!action) return;
 
+        let target = calEvent;
+        // Availabilities are rendered split around clashing shifts (calendarAvailabilitySplit),
+        // giving fragments a synthetic id and truncated times. Resolve back to the real document
+        // so view/edit/delete operate on the underlying availability, not a render artifact.
+        if (calEvent.originalAvailabilityId) {
+            const original = calendarAvailabilities.find(
+                (a) => a.id === calEvent.originalAvailabilityId,
+            );
+            if (original) {
+                const { originalAvailabilityId, ...rest } = calEvent;
+                target = { ...rest, id: original.id, start: original.start, end: original.end };
+            }
+        }
+
         setCalendarAction(action);
-        setCalendarTarget(calEvent);
+        setCalendarTarget(target);
     };
 
     const handleSelectSlot = (slotInfo) => {

--- a/src/components/forms/TutorAvailabilityForm.jsx
+++ b/src/components/forms/TutorAvailabilityForm.jsx
@@ -111,11 +111,12 @@ const TutorAvailabilityForm = ({
     };
 
     const handleDelete = async () => {
+        const availabilityDocId = eventToEdit.originalAvailabilityId || eventToEdit.id;
         try {
-            await deleteEventFromFirestore(eventToEdit.id, 'tutorAvailabilities');
+            await deleteEventFromFirestore(availabilityDocId, 'tutorAvailabilities');
             setCalendarAvailabilities(
                 calendarAvailabilities.filter(
-                    (availability) => availability.id !== eventToEdit.id,
+                    (availability) => availability.id !== availabilityDocId,
                 ),
             );
             return true; // Success - allow modal to close

--- a/tests/unit/calendarAvailability.test.js
+++ b/tests/unit/calendarAvailability.test.js
@@ -1,4 +1,7 @@
-import { isRangeCoveredByTutorAvailability } from '@/utils/calendarAvailability';
+import {
+    isRangeCoveredByTutorAvailability,
+    calendarAvailabilitySplit,
+} from '@/utils/calendarAvailability';
 
 describe('isRangeCoveredByTutorAvailability', () => {
     const tutor = 'tutor@example.edu';
@@ -100,5 +103,47 @@ describe('isRangeCoveredByTutorAvailability', () => {
     test('returns false on missing inputs', () => {
         expect(isRangeCoveredByTutorAvailability(null, new Date(), new Date(), [])).toBe(false);
         expect(isRangeCoveredByTutorAvailability(tutor, null, null, [])).toBe(false);
+    });
+});
+
+describe('calendarAvailabilitySplit', () => {
+    const tutor = 'tutor@example.edu';
+
+    const availability = (start, end, id = 'real-doc-id') => ({
+        id,
+        tutor,
+        start: new Date(start),
+        end: new Date(end),
+    });
+
+    const shift = (start, end, tutorEmail = tutor) => ({
+        start: new Date(start),
+        end: new Date(end),
+        staff: [tutorEmail],
+    });
+
+    test('keeps the real id and no originalAvailabilityId when nothing overlaps', () => {
+        const result = calendarAvailabilitySplit(
+            [availability('2026-05-20T09:00', '2026-05-20T17:00')],
+            [shift('2026-05-21T09:00', '2026-05-21T10:00')],
+        );
+
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('real-doc-id');
+        expect(result[0].originalAvailabilityId).toBeUndefined();
+    });
+
+    test('split fragments carry originalAvailabilityId pointing at the real doc', () => {
+        const result = calendarAvailabilitySplit(
+            [availability('2026-05-20T09:00', '2026-05-20T17:00')],
+            [shift('2026-05-20T12:00', '2026-05-20T13:00')],
+        );
+
+        // The shift in the middle splits the availability into two fragments.
+        expect(result.length).toBeGreaterThan(1);
+        for (const fragment of result) {
+            expect(fragment.id).not.toBe('real-doc-id');
+            expect(fragment.originalAvailabilityId).toBe('real-doc-id');
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Tutor availabilities that overlap a shift are rendered split into fragments by `calendarAvailabilitySplit`, which gives each fragment a synthetic `crypto.randomUUID()` id and truncated start/end times, moving the real Firestore document id into `originalAvailabilityId` (which was previously never read anywhere).
- As a result, delete and edit targeted the nonexistent UUID document: `deleteDoc` on a missing doc silently no-ops, so shift-overlapping availabilities couldn't be deleted and reappeared on the next render. Edit had the same id problem plus would have shrunk the availability to the clicked fragment's times.
- Fixed at the single boundary where a render artifact becomes an interaction target: `handleSelectEvent` now resolves a fragment back to its real underlying availability (real id + full extent) before it enters modal/form state, repairing view, edit, and delete together. Added a defensive id resolution in the form's `handleDelete`, and unit tests locking in the `calendarAvailabilitySplit` → `originalAvailabilityId` contract.

No data migration needed: the split/UUID/truncation happen only at render time, so existing stuck availabilities become deletable as soon as this ships.

## Test plan
- [x] `npx jest tests/unit` — 64 passing (incl. 2 new `calendarAvailabilitySplit` tests)
- [ ] Manual (needs authenticated tutor session): as a tutor/coach, create an availability overlapping an existing shift so it renders split; then:
  - [ ] View/Edit shows the full time range, not the fragment's
  - [ ] Delete removes it and it stays gone after refresh
  - [ ] Edit + save persists to the full availability without truncating times
  - [ ] Regression: a non-overlapping availability still views/edits/deletes correctly