### PR TITLE
Fix dashboard email throttling

### DIFF
--- a/src/app/api/microsoft/msGraphFunctions.js
+++ b/src/app/api/microsoft/msGraphFunctions.js
@@ -21,6 +21,56 @@ const isDevMode = (accessToken) => {
     return isDev && accessToken === 'DEV_MODE_MOCK_TOKEN';
 };
 
+const parseRetryAfterMs = (retryAfter) => {
+    if (!retryAfter) return null;
+
+    const retryAfterSeconds = Number(retryAfter);
+    if (Number.isFinite(retryAfterSeconds)) {
+        return retryAfterSeconds * 1000;
+    }
+
+    const retryAfterDate = new Date(retryAfter).getTime();
+    if (Number.isFinite(retryAfterDate)) {
+        return Math.max(0, retryAfterDate - Date.now());
+    }
+
+    return null;
+};
+
+const readGraphError = async (response) => {
+    try {
+        return await response.json();
+    } catch {
+        try {
+            return { error: { message: await response.text() } };
+        } catch {
+            return { error: { message: response.statusText } };
+        }
+    }
+};
+
+const buildGraphError = async (response, fallbackMessage) => {
+    const graphError = await readGraphError(response);
+    const retryAfter = response.headers?.get?.('retry-after');
+    const requestId =
+        graphError?.error?.innerError?.['request-id'] ||
+        graphError?.error?.innerError?.requestId ||
+        response.headers?.get?.('request-id') ||
+        response.headers?.get?.('client-request-id') ||
+        null;
+    const message = graphError?.error?.message || response.statusText || fallbackMessage;
+    const error = new Error(`${fallbackMessage}: ${message}`);
+
+    error.status = response.status;
+    error.statusText = response.statusText;
+    error.code = graphError?.error?.code || null;
+    error.graphRequestId = requestId;
+    error.retryAfter = retryAfter || null;
+    error.retryAfterMs = parseRetryAfterMs(retryAfter);
+
+    return error;
+};
+
 /**
  * Helper: Build request headers with access token
  */
@@ -494,10 +544,7 @@ export const msSendEmail = async (accessToken, { targetEmail, subject, htmlConte
         });
 
         if (!response.ok) {
-            const error = await response.json();
-            throw new Error(
-                `Failed to send email: ${error.error?.message || response.statusText}`,
-            );
+            throw await buildGraphError(response, 'Failed to send email');
         }
 
         return true;

--- a/src/app/api/send-emails/route.js
+++ b/src/app/api/send-emails/route.js
@@ -6,8 +6,165 @@ import { msSendEmail } from '@/app/api/microsoft/msGraphFunctions';
 import { DateTime } from 'luxon';
 import { sanitiseHtml } from '@/lib/security/securityWrappers';
 
-const TEST_EMAIL_RECIPIENT = 'lhamillmamo@kings.edu.au';
-const DELETE_NOTIFICATIONS_AFTER_SEND = false;
+const EMAIL_SEND_MAX_ATTEMPTS = 3;
+const EMAIL_RETRY_BASE_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 500;
+const EMAIL_RETRY_MAX_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 2000;
+const TRANSIENT_EMAIL_STATUSES = new Set([429, 500, 502, 503, 504]);
+const TRANSIENT_EMAIL_CODES = new Set([
+    'ApplicationThrottled',
+    'ErrorServerBusy',
+    'MailboxConcurrency',
+    'TooManyRequests',
+]);
+const EMAIL_ADDRESS_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export const normaliseRecipientEmail = (member) => {
+    const email = typeof member === 'string'
+        ? member
+        : member?.value || member?.email || '';
+    return typeof email === 'string' ? email.trim().toLowerCase() : '';
+};
+
+export const isValidEmailAddress = (email) => EMAIL_ADDRESS_RE.test(email);
+
+export const buildTutorEmailEntries = (notifications) => {
+    const tutorMap = new Map();
+    const invalidRecipients = [];
+
+    for (const notification of notifications) {
+        const seenForNotification = new Set();
+
+        for (const member of (notification.staff || [])) {
+            const email = normaliseRecipientEmail(member);
+            if (!isValidEmailAddress(email)) {
+                invalidRecipients.push({
+                    notificationId: notification.id,
+                    recipient: String(member?.value || member?.email || member || 'missing'),
+                    reason: 'Invalid or missing tutor email address',
+                });
+                continue;
+            }
+
+            if (seenForNotification.has(email)) continue;
+            seenForNotification.add(email);
+
+            if (!tutorMap.has(email)) tutorMap.set(email, []);
+            tutorMap.get(email).push(notification);
+        }
+    }
+
+    return {
+        tutorEntries: Array.from(tutorMap.entries()),
+        invalidRecipients,
+    };
+};
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const redactEmail = (email) => {
+    if (!email || !email.includes('@')) return 'unknown recipient';
+
+    const [localPart, domain] = email.split('@');
+    const visibleLocal = localPart.slice(0, 1);
+    return `${visibleLocal}${'*'.repeat(Math.max(localPart.length - 1, 1))}@${domain}`;
+};
+
+const serialiseEmailError = (error) => ({
+    message: error?.message || 'Unknown email send failure',
+    status: error?.status || null,
+    code: error?.code || null,
+    graphRequestId: error?.graphRequestId || null,
+    retryAfter: error?.retryAfter || null,
+    attempts: error?.attempts || null,
+});
+
+const failureReason = (error) =>
+    error?.code ||
+    error?.statusText ||
+    (error?.status ? `HTTP ${error.status}` : null) ||
+    error?.message ||
+    'Unknown failure';
+
+const isTransientEmailError = (error) => {
+    const message = String(error?.message || '').toLowerCase();
+    return (
+        TRANSIENT_EMAIL_STATUSES.has(error?.status) ||
+        TRANSIENT_EMAIL_CODES.has(error?.code) ||
+        message.includes('mailboxconcurrency') ||
+        message.includes('too many requests') ||
+        message.includes('server busy')
+    );
+};
+
+const getRetryDelayMs = (error, attempt) => {
+    if (Number.isFinite(error?.retryAfterMs)) {
+        return Math.min(error.retryAfterMs, EMAIL_RETRY_MAX_DELAY_MS);
+    }
+
+    return Math.min(
+        EMAIL_RETRY_BASE_DELAY_MS * (2 ** Math.max(attempt - 1, 0)),
+        EMAIL_RETRY_MAX_DELAY_MS
+    );
+};
+
+export const sendEmailWithRetry = async (
+    accessToken,
+    emailData,
+    {
+        sendEmail = msSendEmail,
+        sleep = delay,
+        maxAttempts = EMAIL_SEND_MAX_ATTEMPTS,
+    } = {}
+) => {
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        try {
+            return await sendEmail(accessToken, emailData);
+        } catch (error) {
+            error.attempts = attempt;
+            const shouldRetry = attempt < maxAttempts && isTransientEmailError(error);
+            if (!shouldRetry) {
+                throw error;
+            }
+
+            await sleep(getRetryDelayMs(error, attempt));
+        }
+    }
+
+    return false;
+};
+
+const buildFailureDetails = (sendFailures, invalidRecipients) => [
+    ...sendFailures.map((failure) => ({
+        recipient: redactEmail(failure.tutorEmail),
+        reason: failureReason(failure.reason),
+        status: failure.reason?.status || null,
+        code: failure.reason?.code || null,
+        requestId: failure.reason?.graphRequestId || null,
+        attempts: failure.reason?.attempts || null,
+    })),
+    ...invalidRecipients.map((failure) => ({
+        recipient: redactEmail(failure.recipient),
+        reason: failure.reason,
+        status: null,
+        code: 'INVALID_RECIPIENT',
+        requestId: null,
+        attempts: 0,
+    })),
+];
+
+const buildFailureMessage = (failureDetails) => {
+    if (failureDetails.length === 0) return '';
+
+    const visibleFailures = failureDetails
+        .slice(0, 3)
+        .map((failure) => `${failure.recipient}: ${failure.reason}`)
+        .join('; ');
+    const remaining = failureDetails.length > 3
+        ? `; ${failureDetails.length - 3} more`
+        : '';
+
+    return ` Failed: ${visibleFailures}${remaining}.`;
+};
 
 export async function POST(req) {
     const session = await getServerSession(authOptions);
@@ -36,43 +193,39 @@ export async function POST(req) {
 
         const notifications = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
 
-        const tutorMap = new Map();
-        for (const notification of notifications) {
-            for (const member of (notification.staff || [])) {
-                const email = member.value || member;
-                if (!tutorMap.has(email)) tutorMap.set(email, []);
-                tutorMap.get(email).push(notification);
+        const { tutorEntries, invalidRecipients } = buildTutorEmailEntries(notifications);
+        if (tutorEntries.length === 0 && invalidRecipients.length === 0) {
+            return Response.json({ message: 'No tutor recipients found in queued notifications.' }, { status: 400 });
+        }
+
+        const results = [];
+        for (const [tutorEmail, tutorNotifications] of tutorEntries) {
+            try {
+                await sendEmailWithRetry(msAccessToken, {
+                    targetEmail: tutorEmail,
+                    subject: 'Talloc Shift Notification',
+                    htmlContent: buildEmailHTML(tutorNotifications),
+                    saveToSentItems: true,
+                });
+                results.push({ status: 'fulfilled', tutorEmail, tutorNotifications });
+            } catch (error) {
+                results.push({ status: 'rejected', tutorEmail, tutorNotifications, reason: error });
             }
         }
 
-        const tutorEntries = Array.from(tutorMap.entries());
-        const results = await Promise.allSettled(
-            tutorEntries.map(([tutorEmail, tutorNotifications]) =>
-                msSendEmail(msAccessToken, {
-                    targetEmail: TEST_EMAIL_RECIPIENT,
-                    subject: `Talloc Shift Notification (TEST for ${tutorEmail})`,
-                    htmlContent: buildEmailHTML(tutorNotifications, tutorEmail),
-                    saveToSentItems: true,
-                })
-            )
-        );
-
         // Track notifications that had at least one failed send — keep those for retry
-        const failedNotifIds = new Set();
-        results.forEach((result, i) => {
+        const failedNotifIds = new Set(invalidRecipients.map((failure) => failure.notificationId));
+        results.forEach((result) => {
             if (result.status === 'rejected') {
-                console.error(
-                    `[send-emails] Failed to send test email for ${tutorEntries[i][0]} to ${TEST_EMAIL_RECIPIENT}:`,
-                    result.reason
-                );
-                for (const n of tutorEntries[i][1]) {
+                console.error(`[send-emails] Failed to send to ${result.tutorEmail}:`, serialiseEmailError(result.reason));
+                for (const n of result.tutorNotifications) {
                     failedNotifIds.add(n.id);
                 }
             }
         });
 
         const idsToDelete = notifications.map((n) => n.id).filter((id) => !failedNotifIds.has(id));
-        if (DELETE_NOTIFICATIONS_AFTER_SEND && idsToDelete.length > 0) {
+        if (idsToDelete.length > 0) {
             const batch = adminDb.batch();
             for (const id of idsToDelete) {
                 batch.delete(adminDb.collection('emailNotifications').doc(id));
@@ -80,15 +233,21 @@ export async function POST(req) {
             await batch.commit();
         }
 
-        const failCount = results.filter((r) => r.status === 'rejected').length;
+        const sendFailures = results.filter((r) => r.status === 'rejected');
+        const failCount = sendFailures.length + invalidRecipients.length;
+        const totalRecipients = tutorEntries.length + invalidRecipients.length;
         if (failCount > 0) {
+            const failureDetails = buildFailureDetails(sendFailures, invalidRecipients);
             return Response.json(
-                { message: `${tutorEntries.length - failCount} of ${tutorEntries.length} test emails sent to ${TEST_EMAIL_RECIPIENT}. ${failCount} failed — retry to resend. Notifications were left queued.` },
+                {
+                    message: `${totalRecipients - failCount} of ${totalRecipients} emails sent. ${failCount} failed or skipped — retry to resend.${buildFailureMessage(failureDetails)}`,
+                    failures: failureDetails,
+                },
                 { status: 500 }
             );
         }
 
-        return Response.json({ message: `${tutorEntries.length} test email(s) sent to ${TEST_EMAIL_RECIPIENT}. Notifications were left queued.` });
+        return Response.json({ message: `Emails sent to ${tutorEntries.length} tutor(s).` });
     } catch (error) {
         console.error('[send-emails] Unexpected error:', error);
         return Response.json({ message: 'Failed to send emails' }, { status: 500 });
@@ -159,7 +318,7 @@ function buildEventRow(notification, index, total) {
     }
 }
 
-function buildEmailHTML(notifications, originalRecipient) {
+function buildEmailHTML(notifications) {
     const rows = notifications
         .map((notification, index) => buildEventRow(notification, index, notifications.length))
         .join('');
@@ -195,17 +354,6 @@ function buildEmailHTML(notifications, originalRecipient) {
               <p style="margin:0 0 28px 0;color:#4b5563;font-size:15px;line-height:1.7;">
                 You have been added to the following shifts or your times have been adjusted. Please review the details below.
               </p>
-
-              <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
-                <tr>
-                  <td style="background-color:#fef3c7;border:1px solid #f59e0b;border-radius:8px;padding:14px 16px;">
-                    <p style="margin:0;color:#92400e;font-size:13px;line-height:1.5;">
-                      <strong>Test redirect:</strong> this email would normally be sent to ${sanitiseHtml(originalRecipient)}.
-                      It was sent to ${TEST_EMAIL_RECIPIENT} for testing.
-                    </p>
-                  </td>
-                </tr>
-              </table>
 
               <!-- Shift cards -->
               <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:36px;">

--- a/src/app/api/send-emails/route.js
+++ b/src/app/api/send-emails/route.js
@@ -9,6 +9,8 @@ import { sanitiseHtml } from '@/lib/security/securityWrappers';
 const EMAIL_SEND_MAX_ATTEMPTS = 3;
 const EMAIL_RETRY_BASE_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 500;
 const EMAIL_RETRY_MAX_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 2000;
+const TEST_EMAIL_RECIPIENT = 'lhamillmamo@kings.edu.au';
+const DELETE_NOTIFICATIONS_AFTER_SEND = false;
 const TRANSIENT_EMAIL_STATUSES = new Set([429, 500, 502, 503, 504]);
 const TRANSIENT_EMAIL_CODES = new Set([
     'ApplicationThrottled',
@@ -202,9 +204,9 @@ export async function POST(req) {
         for (const [tutorEmail, tutorNotifications] of tutorEntries) {
             try {
                 await sendEmailWithRetry(msAccessToken, {
-                    targetEmail: tutorEmail,
-                    subject: 'Talloc Shift Notification',
-                    htmlContent: buildEmailHTML(tutorNotifications),
+                    targetEmail: TEST_EMAIL_RECIPIENT,
+                    subject: `Talloc Shift Notification (TEST for ${tutorEmail})`,
+                    htmlContent: buildEmailHTML(tutorNotifications, tutorEmail),
                     saveToSentItems: true,
                 });
                 results.push({ status: 'fulfilled', tutorEmail, tutorNotifications });
@@ -217,7 +219,10 @@ export async function POST(req) {
         const failedNotifIds = new Set(invalidRecipients.map((failure) => failure.notificationId));
         results.forEach((result) => {
             if (result.status === 'rejected') {
-                console.error(`[send-emails] Failed to send to ${result.tutorEmail}:`, serialiseEmailError(result.reason));
+                console.error(
+                    `[send-emails] Failed to send test email for ${result.tutorEmail} to ${TEST_EMAIL_RECIPIENT}:`,
+                    serialiseEmailError(result.reason)
+                );
                 for (const n of result.tutorNotifications) {
                     failedNotifIds.add(n.id);
                 }
@@ -225,7 +230,7 @@ export async function POST(req) {
         });
 
         const idsToDelete = notifications.map((n) => n.id).filter((id) => !failedNotifIds.has(id));
-        if (idsToDelete.length > 0) {
+        if (DELETE_NOTIFICATIONS_AFTER_SEND && idsToDelete.length > 0) {
             const batch = adminDb.batch();
             for (const id of idsToDelete) {
                 batch.delete(adminDb.collection('emailNotifications').doc(id));
@@ -240,14 +245,14 @@ export async function POST(req) {
             const failureDetails = buildFailureDetails(sendFailures, invalidRecipients);
             return Response.json(
                 {
-                    message: `${totalRecipients - failCount} of ${totalRecipients} emails sent. ${failCount} failed or skipped — retry to resend.${buildFailureMessage(failureDetails)}`,
+                    message: `${totalRecipients - failCount} of ${totalRecipients} test emails sent to ${TEST_EMAIL_RECIPIENT}. ${failCount} failed or skipped — retry to resend. Notifications were left queued.${buildFailureMessage(failureDetails)}`,
                     failures: failureDetails,
                 },
                 { status: 500 }
             );
         }
 
-        return Response.json({ message: `Emails sent to ${tutorEntries.length} tutor(s).` });
+        return Response.json({ message: `${tutorEntries.length} test email(s) sent to ${TEST_EMAIL_RECIPIENT}. Notifications were left queued.` });
     } catch (error) {
         console.error('[send-emails] Unexpected error:', error);
         return Response.json({ message: 'Failed to send emails' }, { status: 500 });
@@ -318,7 +323,7 @@ function buildEventRow(notification, index, total) {
     }
 }
 
-function buildEmailHTML(notifications) {
+function buildEmailHTML(notifications, originalRecipient) {
     const rows = notifications
         .map((notification, index) => buildEventRow(notification, index, notifications.length))
         .join('');
@@ -354,6 +359,17 @@ function buildEmailHTML(notifications) {
               <p style="margin:0 0 28px 0;color:#4b5563;font-size:15px;line-height:1.7;">
                 You have been added to the following shifts or your times have been adjusted. Please review the details below.
               </p>
+
+              <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
+                <tr>
+                  <td style="background-color:#fef3c7;border:1px solid #f59e0b;border-radius:8px;padding:14px 16px;">
+                    <p style="margin:0;color:#92400e;font-size:13px;line-height:1.5;">
+                      <strong>Test redirect:</strong> this email would normally be sent to ${sanitiseHtml(originalRecipient)}.
+                      It was sent to ${TEST_EMAIL_RECIPIENT} for testing.
+                    </p>
+                  </td>
+                </tr>
+              </table>
 
               <!-- Shift cards -->
               <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:36px;">

--- a/src/components/DashboardOverview.jsx
+++ b/src/components/DashboardOverview.jsx
@@ -17,6 +17,7 @@ const DashboardOverview = () => {
     const isAdmin = userRole === 'admin' || userRoles?.includes('admin');
     const { addAlert } = useAlert();
     const [needsReauth, setNeedsReauth] = useState(false);
+    const [isSendingEmails, setIsSendingEmails] = useState(false);
     const {
         calendarShifts,
         calendarStudentRequests,
@@ -258,6 +259,9 @@ const DashboardOverview = () => {
 
 
     const handleSendEmailNotifications = async () => {
+        if (isSendingEmails) return;
+
+        setIsSendingEmails(true);
         try {
             const response = await fetch('/api/send-emails', { method: 'POST' });
             const data = await response.json();
@@ -279,6 +283,8 @@ const DashboardOverview = () => {
             addAlert('success', data.message || 'Emails sent successfully');
         } catch (error) {
             addAlert('error', error.message || 'Failed to send emails');
+        } finally {
+            setIsSendingEmails(false);
         }
     };
 
@@ -305,8 +311,10 @@ const DashboardOverview = () => {
                         <button
                             className="btn btn-outline-success"
                             onClick={handleSendEmailNotifications}
+                            disabled={isSendingEmails}
+                            aria-busy={isSendingEmails}
                         >
-                            Email Shift Notifications
+                            {isSendingEmails ? 'Sending Shift Notifications...' : 'Email Shift Notifications'}
                         </button>
                     </div>
                 </div>

--- a/tests/unit/sendEmailsRoute.test.js
+++ b/tests/unit/sendEmailsRoute.test.js
@@ -1,0 +1,219 @@
+jest.mock('@/firestore/firestoreAdmin', () => ({
+    adminDb: {
+        collection: jest.fn(),
+        batch: jest.fn(),
+    },
+}));
+
+jest.mock('next-auth/next', () => ({
+    getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/security/authConfig', () => ({
+    authOptions: {},
+}));
+
+jest.mock('@/lib/microsoft/tokenUtils', () => ({
+    getMicrosoftAccessToken: jest.fn(),
+}));
+
+jest.mock('@/app/api/microsoft/msGraphFunctions', () => ({
+    msSendEmail: jest.fn(),
+}));
+
+jest.mock('@/lib/security/securityWrappers', () => ({
+    sanitiseHtml: (value) => String(value || ''),
+}));
+
+if (!global.Response.json) {
+    global.Response.json = (body, init = {}) => new global.Response(JSON.stringify(body), init);
+}
+
+const { adminDb } = require('@/firestore/firestoreAdmin');
+const { getServerSession } = require('next-auth/next');
+const { getMicrosoftAccessToken } = require('@/lib/microsoft/tokenUtils');
+const { msSendEmail } = require('@/app/api/microsoft/msGraphFunctions');
+const {
+    POST,
+    buildTutorEmailEntries,
+    sendEmailWithRetry,
+} = require('@/app/api/send-emails/route');
+
+const notificationDoc = (id, data) => ({
+    id,
+    data: () => data,
+});
+
+const graphError = (message, overrides = {}) => Object.assign(new Error(message), overrides);
+
+const mockEmailNotificationSnapshot = (docs) => {
+    const get = jest.fn().mockResolvedValue({ empty: docs.length === 0, docs });
+    const where = jest.fn().mockReturnValue({ get });
+    const doc = jest.fn((id) => ({ id }));
+    adminDb.collection.mockReturnValue({ where, doc });
+
+    return { where, get, doc };
+};
+
+const mockBatch = () => {
+    const batch = {
+        delete: jest.fn(),
+        commit: jest.fn().mockResolvedValue(undefined),
+    };
+    adminDb.batch.mockReturnValue(batch);
+    return batch;
+};
+
+describe('send email route helpers', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('retries transient Graph mailbox concurrency failures', async () => {
+        const transientError = graphError('Application is over its MailboxConcurrency limit.', {
+            status: 429,
+            code: 'ApplicationThrottled',
+        });
+        const sendEmail = jest.fn()
+            .mockRejectedValueOnce(transientError)
+            .mockResolvedValueOnce(true);
+        const sleep = jest.fn().mockResolvedValue(undefined);
+
+        await expect(sendEmailWithRetry(
+            'token',
+            { targetEmail: 'tutor@kings.edu.au' },
+            { sendEmail, sleep },
+        )).resolves.toBe(true);
+
+        expect(sendEmail).toHaveBeenCalledTimes(2);
+        expect(sleep).toHaveBeenCalledWith(0);
+    });
+
+    it('normalises recipient shapes and skips invalid addresses', () => {
+        const notifications = [
+            {
+                id: 'shift-1',
+                staff: [
+                    { value: ' Tutor@Kings.edu.au ' },
+                    { email: 'coach@kings.edu.au' },
+                    'tutor@kings.edu.au',
+                    'not-an-email',
+                    { label: 'Missing Email' },
+                ],
+            },
+        ];
+
+        const { tutorEntries, invalidRecipients } = buildTutorEmailEntries(notifications);
+
+        expect(tutorEntries).toEqual([
+            ['tutor@kings.edu.au', [notifications[0]]],
+            ['coach@kings.edu.au', [notifications[0]]],
+        ]);
+        expect(invalidRecipients).toHaveLength(2);
+    });
+});
+
+describe('POST /api/send-emails', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        getServerSession.mockResolvedValue({
+            user: {
+                email: 'admin@kings.edu.au',
+                defaultRole: 'admin',
+                userRoles: [],
+            },
+        });
+        getMicrosoftAccessToken.mockResolvedValue('ms-token');
+        mockBatch();
+    });
+
+    afterEach(() => {
+        console.error.mockRestore();
+    });
+
+    it('sends sequential recipient emails and keeps failed notification docs queued', async () => {
+        const docs = [
+            notificationDoc('shift-1', {
+                title: 'Shared shift',
+                action: 'allocated',
+                start: new Date('2026-05-25T01:00:00Z'),
+                end: new Date('2026-05-25T02:00:00Z'),
+                staff: [
+                    { value: 'success@kings.edu.au' },
+                    { value: 'failure@kings.edu.au' },
+                ],
+                createdByEmail: 'admin@kings.edu.au',
+            }),
+            notificationDoc('shift-2', {
+                title: 'Success shift',
+                action: 'allocated',
+                start: new Date('2026-05-25T03:00:00Z'),
+                end: new Date('2026-05-25T04:00:00Z'),
+                staff: [{ value: 'success@kings.edu.au' }],
+                createdByEmail: 'admin@kings.edu.au',
+            }),
+        ];
+        const { doc } = mockEmailNotificationSnapshot(docs);
+        const batch = mockBatch();
+        msSendEmail.mockImplementation((token, { targetEmail }) => {
+            if (targetEmail === 'failure@kings.edu.au') {
+                return Promise.reject(graphError('No mailbox', {
+                    status: 400,
+                    code: 'ErrorInvalidRecipients',
+                }));
+            }
+            return Promise.resolve(true);
+        });
+
+        const response = await POST({});
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.message).toContain('1 of 2 emails sent');
+        expect(body.failures).toEqual([
+            expect.objectContaining({
+                recipient: 'f******@kings.edu.au',
+                code: 'ErrorInvalidRecipients',
+            }),
+        ]);
+        expect(msSendEmail.mock.calls.map(([, emailData]) => emailData.targetEmail)).toEqual([
+            'success@kings.edu.au',
+            'failure@kings.edu.au',
+        ]);
+        expect(doc).toHaveBeenCalledWith('shift-2');
+        expect(batch.delete).toHaveBeenCalledWith({ id: 'shift-2' });
+        expect(batch.delete).not.toHaveBeenCalledWith({ id: 'shift-1' });
+        expect(batch.commit).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports invalid recipients without calling Microsoft Graph', async () => {
+        const docs = [
+            notificationDoc('shift-1', {
+                title: 'Invalid recipient shift',
+                action: 'allocated',
+                start: new Date('2026-05-25T01:00:00Z'),
+                end: new Date('2026-05-25T02:00:00Z'),
+                staff: [{ value: 'not-an-email' }],
+                createdByEmail: 'admin@kings.edu.au',
+            }),
+        ];
+        mockEmailNotificationSnapshot(docs);
+        const batch = mockBatch();
+
+        const response = await POST({});
+        const body = await response.json();
+
+        expect(response.status).toBe(500);
+        expect(body.message).toContain('0 of 1 emails sent');
+        expect(body.failures).toEqual([
+            expect.objectContaining({
+                code: 'INVALID_RECIPIENT',
+                reason: 'Invalid or missing tutor email address',
+            }),
+        ]);
+        expect(msSendEmail).not.toHaveBeenCalled();
+        expect(batch.delete).not.toHaveBeenCalled();
+        expect(batch.commit).not.toHaveBeenCalled();
+    });
+});

--- a/tests/unit/sendEmailsRoute.test.js
+++ b/tests/unit/sendEmailsRoute.test.js
@@ -132,7 +132,7 @@ describe('POST /api/send-emails', () => {
         console.error.mockRestore();
     });
 
-    it('sends sequential recipient emails and keeps failed notification docs queued', async () => {
+    it('sends sequential test emails and leaves notification docs queued', async () => {
         const docs = [
             notificationDoc('shift-1', {
                 title: 'Shared shift',
@@ -154,10 +154,10 @@ describe('POST /api/send-emails', () => {
                 createdByEmail: 'admin@kings.edu.au',
             }),
         ];
-        const { doc } = mockEmailNotificationSnapshot(docs);
+        mockEmailNotificationSnapshot(docs);
         const batch = mockBatch();
-        msSendEmail.mockImplementation((token, { targetEmail }) => {
-            if (targetEmail === 'failure@kings.edu.au') {
+        msSendEmail.mockImplementation((token, { subject }) => {
+            if (subject.includes('failure@kings.edu.au')) {
                 return Promise.reject(graphError('No mailbox', {
                     status: 400,
                     code: 'ErrorInvalidRecipients',
@@ -170,7 +170,8 @@ describe('POST /api/send-emails', () => {
         const body = await response.json();
 
         expect(response.status).toBe(500);
-        expect(body.message).toContain('1 of 2 emails sent');
+        expect(body.message).toContain('1 of 2 test emails sent to lhamillmamo@kings.edu.au');
+        expect(body.message).toContain('Notifications were left queued');
         expect(body.failures).toEqual([
             expect.objectContaining({
                 recipient: 'f******@kings.edu.au',
@@ -178,13 +179,15 @@ describe('POST /api/send-emails', () => {
             }),
         ]);
         expect(msSendEmail.mock.calls.map(([, emailData]) => emailData.targetEmail)).toEqual([
-            'success@kings.edu.au',
-            'failure@kings.edu.au',
+            'lhamillmamo@kings.edu.au',
+            'lhamillmamo@kings.edu.au',
         ]);
-        expect(doc).toHaveBeenCalledWith('shift-2');
-        expect(batch.delete).toHaveBeenCalledWith({ id: 'shift-2' });
-        expect(batch.delete).not.toHaveBeenCalledWith({ id: 'shift-1' });
-        expect(batch.commit).toHaveBeenCalledTimes(1);
+        expect(msSendEmail.mock.calls.map(([, emailData]) => emailData.subject)).toEqual([
+            'Talloc Shift Notification (TEST for success@kings.edu.au)',
+            'Talloc Shift Notification (TEST for failure@kings.edu.au)',
+        ]);
+        expect(batch.delete).not.toHaveBeenCalled();
+        expect(batch.commit).not.toHaveBeenCalled();
     });
 
     it('reports invalid recipients without calling Microsoft Graph', async () => {
@@ -205,7 +208,7 @@ describe('POST /api/send-emails', () => {
         const body = await response.json();
 
         expect(response.status).toBe(500);
-        expect(body.message).toContain('0 of 1 emails sent');
+        expect(body.message).toContain('0 of 1 test emails sent to lhamillmamo@kings.edu.au');
         expect(body.failures).toEqual([
             expect.objectContaining({
                 code: 'INVALID_RECIPIENT',


### PR DESCRIPTION
## Summary
- Send dashboard shift notification emails sequentially with bounded retry/backoff for transient Microsoft Graph throttling failures.
- Preserve Graph failure metadata and return redacted recipient-level failure details for admin troubleshooting.
- Normalize/validate tutor recipient addresses and prevent repeated dashboard send clicks while a request is in flight.

## Test plan
- `npm test -- --runTestsByPath tests/unit/sendEmailsRoute.test.js`
- `npm run lint`
- `npm test`