### PR TITLE
Remove email test redirect

### DIFF
--- a/src/app/api/send-emails/route.js
+++ b/src/app/api/send-emails/route.js
@@ -9,8 +9,6 @@ import { sanitiseHtml } from '@/lib/security/securityWrappers';
 const EMAIL_SEND_MAX_ATTEMPTS = 3;
 const EMAIL_RETRY_BASE_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 500;
 const EMAIL_RETRY_MAX_DELAY_MS = process.env.NODE_ENV === 'test' ? 0 : 2000;
-const TEST_EMAIL_RECIPIENT = 'lhamillmamo@kings.edu.au';
-const DELETE_NOTIFICATIONS_AFTER_SEND = false;
 const TRANSIENT_EMAIL_STATUSES = new Set([429, 500, 502, 503, 504]);
 const TRANSIENT_EMAIL_CODES = new Set([
     'ApplicationThrottled',
@@ -204,9 +202,9 @@ export async function POST(req) {
         for (const [tutorEmail, tutorNotifications] of tutorEntries) {
             try {
                 await sendEmailWithRetry(msAccessToken, {
-                    targetEmail: TEST_EMAIL_RECIPIENT,
-                    subject: `Talloc Shift Notification (TEST for ${tutorEmail})`,
-                    htmlContent: buildEmailHTML(tutorNotifications, tutorEmail),
+                    targetEmail: tutorEmail,
+                    subject: 'Talloc Shift Notification',
+                    htmlContent: buildEmailHTML(tutorNotifications),
                     saveToSentItems: true,
                 });
                 results.push({ status: 'fulfilled', tutorEmail, tutorNotifications });
@@ -219,10 +217,7 @@ export async function POST(req) {
         const failedNotifIds = new Set(invalidRecipients.map((failure) => failure.notificationId));
         results.forEach((result) => {
             if (result.status === 'rejected') {
-                console.error(
-                    `[send-emails] Failed to send test email for ${result.tutorEmail} to ${TEST_EMAIL_RECIPIENT}:`,
-                    serialiseEmailError(result.reason)
-                );
+                console.error(`[send-emails] Failed to send to ${result.tutorEmail}:`, serialiseEmailError(result.reason));
                 for (const n of result.tutorNotifications) {
                     failedNotifIds.add(n.id);
                 }
@@ -230,7 +225,7 @@ export async function POST(req) {
         });
 
         const idsToDelete = notifications.map((n) => n.id).filter((id) => !failedNotifIds.has(id));
-        if (DELETE_NOTIFICATIONS_AFTER_SEND && idsToDelete.length > 0) {
+        if (idsToDelete.length > 0) {
             const batch = adminDb.batch();
             for (const id of idsToDelete) {
                 batch.delete(adminDb.collection('emailNotifications').doc(id));
@@ -245,14 +240,14 @@ export async function POST(req) {
             const failureDetails = buildFailureDetails(sendFailures, invalidRecipients);
             return Response.json(
                 {
-                    message: `${totalRecipients - failCount} of ${totalRecipients} test emails sent to ${TEST_EMAIL_RECIPIENT}. ${failCount} failed or skipped — retry to resend. Notifications were left queued.${buildFailureMessage(failureDetails)}`,
+                    message: `${totalRecipients - failCount} of ${totalRecipients} emails sent. ${failCount} failed or skipped — retry to resend.${buildFailureMessage(failureDetails)}`,
                     failures: failureDetails,
                 },
                 { status: 500 }
             );
         }
 
-        return Response.json({ message: `${tutorEntries.length} test email(s) sent to ${TEST_EMAIL_RECIPIENT}. Notifications were left queued.` });
+        return Response.json({ message: `Emails sent to ${tutorEntries.length} tutor(s).` });
     } catch (error) {
         console.error('[send-emails] Unexpected error:', error);
         return Response.json({ message: 'Failed to send emails' }, { status: 500 });
@@ -323,7 +318,7 @@ function buildEventRow(notification, index, total) {
     }
 }
 
-function buildEmailHTML(notifications, originalRecipient) {
+function buildEmailHTML(notifications) {
     const rows = notifications
         .map((notification, index) => buildEventRow(notification, index, notifications.length))
         .join('');
@@ -359,17 +354,6 @@ function buildEmailHTML(notifications, originalRecipient) {
               <p style="margin:0 0 28px 0;color:#4b5563;font-size:15px;line-height:1.7;">
                 You have been added to the following shifts or your times have been adjusted. Please review the details below.
               </p>
-
-              <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
-                <tr>
-                  <td style="background-color:#fef3c7;border:1px solid #f59e0b;border-radius:8px;padding:14px 16px;">
-                    <p style="margin:0;color:#92400e;font-size:13px;line-height:1.5;">
-                      <strong>Test redirect:</strong> this email would normally be sent to ${sanitiseHtml(originalRecipient)}.
-                      It was sent to ${TEST_EMAIL_RECIPIENT} for testing.
-                    </p>
-                  </td>
-                </tr>
-              </table>
 
               <!-- Shift cards -->
               <table width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:36px;">

--- a/tests/unit/sendEmailsRoute.test.js
+++ b/tests/unit/sendEmailsRoute.test.js
@@ -132,7 +132,7 @@ describe('POST /api/send-emails', () => {
         console.error.mockRestore();
     });
 
-    it('sends sequential test emails and leaves notification docs queued', async () => {
+    it('sends sequential recipient emails and keeps failed notification docs queued', async () => {
         const docs = [
             notificationDoc('shift-1', {
                 title: 'Shared shift',
@@ -154,10 +154,10 @@ describe('POST /api/send-emails', () => {
                 createdByEmail: 'admin@kings.edu.au',
             }),
         ];
-        mockEmailNotificationSnapshot(docs);
+        const { doc } = mockEmailNotificationSnapshot(docs);
         const batch = mockBatch();
-        msSendEmail.mockImplementation((token, { subject }) => {
-            if (subject.includes('failure@kings.edu.au')) {
+        msSendEmail.mockImplementation((token, { targetEmail }) => {
+            if (targetEmail === 'failure@kings.edu.au') {
                 return Promise.reject(graphError('No mailbox', {
                     status: 400,
                     code: 'ErrorInvalidRecipients',
@@ -170,8 +170,7 @@ describe('POST /api/send-emails', () => {
         const body = await response.json();
 
         expect(response.status).toBe(500);
-        expect(body.message).toContain('1 of 2 test emails sent to lhamillmamo@kings.edu.au');
-        expect(body.message).toContain('Notifications were left queued');
+        expect(body.message).toContain('1 of 2 emails sent');
         expect(body.failures).toEqual([
             expect.objectContaining({
                 recipient: 'f******@kings.edu.au',
@@ -179,15 +178,13 @@ describe('POST /api/send-emails', () => {
             }),
         ]);
         expect(msSendEmail.mock.calls.map(([, emailData]) => emailData.targetEmail)).toEqual([
-            'lhamillmamo@kings.edu.au',
-            'lhamillmamo@kings.edu.au',
+            'success@kings.edu.au',
+            'failure@kings.edu.au',
         ]);
-        expect(msSendEmail.mock.calls.map(([, emailData]) => emailData.subject)).toEqual([
-            'Talloc Shift Notification (TEST for success@kings.edu.au)',
-            'Talloc Shift Notification (TEST for failure@kings.edu.au)',
-        ]);
-        expect(batch.delete).not.toHaveBeenCalled();
-        expect(batch.commit).not.toHaveBeenCalled();
+        expect(doc).toHaveBeenCalledWith('shift-2');
+        expect(batch.delete).toHaveBeenCalledWith({ id: 'shift-2' });
+        expect(batch.delete).not.toHaveBeenCalledWith({ id: 'shift-1' });
+        expect(batch.commit).toHaveBeenCalledTimes(1);
     });
 
     it('reports invalid recipients without calling Microsoft Graph', async () => {
@@ -208,7 +205,7 @@ describe('POST /api/send-emails', () => {
         const body = await response.json();
 
         expect(response.status).toBe(500);
-        expect(body.message).toContain('0 of 1 test emails sent to lhamillmamo@kings.edu.au');
+        expect(body.message).toContain('0 of 1 emails sent');
         expect(body.failures).toEqual([
             expect.objectContaining({
                 code: 'INVALID_RECIPIENT',


### PR DESCRIPTION
## Summary
- Remove the temporary dashboard email test redirect to `lhamillmamo@kings.edu.au`.
- Restore sends to real tutor recipients and normal cleanup of successfully sent notification docs.
- Update email route tests back to production recipient behavior.

## Test plan
- `npm test -- --runTestsByPath tests/unit/sendEmailsRoute.test.js`
- `npm run lint`
- `npm test`