### PR TITLE
feat: Hold C + click to toggle shift completion status

### DIFF
--- a/src/components/calendar/CalendarContent.jsx
+++ b/src/components/calendar/CalendarContent.jsx
@@ -12,7 +12,7 @@ import { useAppData } from '@/contexts/AppDataContext';
 import useCalendarStrategy from '@/hooks/useCalendarStrategy';
 import useAuthSession from '@/hooks/useAuthSession';
 import useAlert from '@/hooks/useAlert';
-import { updateEventInFirestore, createEventInFirestore } from '@/firestore/firestoreOperations';
+import { updateEventInFirestore, createEventInFirestore, updateWorkStatusInFirestore } from '@/firestore/firestoreOperations';
 import { calendarEventCreateTeamsMeeting, calendarEventUpdateTeamsMeeting } from '@/utils/calendarEvent';
 import { detachRecurringInstance } from '@/utils/calendarRecurringEvents';
 
@@ -27,6 +27,13 @@ import { calendarUIGetEventStyle, calendarUIMessages } from '@/utils/calendarUI'
 import { isRangeCoveredByTutorAvailability, getTutorShiftConflicts } from '@/utils/calendarAvailability';
 
 const { memo } = React;
+
+const KEY_WINDOW_MS = 600;
+const isFormElement = (el) => {
+    if (!el) return false;
+    const tag = el.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+};
 
 /* ───────────────────────────────────────────────────────────── */
 /* RBC setup                                                     */
@@ -211,10 +218,58 @@ const CalendarContent = () => {
     }, []);
 
 
+    // track the bare 'C' key for the hold-C-to-complete shortcut
+    const cKeyTimestampRef = React.useRef(0);
+
+    React.useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (isFormElement(document.activeElement)) return;
+            if (!e.metaKey && !e.ctrlKey && e.key.toLowerCase() === 'c') {
+                cKeyTimestampRef.current = Date.now();
+            }
+        };
+        window.addEventListener('keydown', handleKeyDown);
+        return () => window.removeEventListener('keydown', handleKeyDown);
+    }, []);
+
+    const isCKeyRecent = () => {
+        const ts = cKeyTimestampRef.current;
+        if (!ts) return false;
+        const recent = Date.now() - ts < KEY_WINDOW_MS;
+        if (recent) cKeyTimestampRef.current = 0; // consume
+        return recent;
+    };
+
     /* ----------------------------------------------------------- */
     /* Handlers                                                    */
     /* ----------------------------------------------------------- */
-    const handleSelectEvent = (calEvent) => {
+    const handleSelectEvent = async (calEvent) => {
+        // C + click: quick-toggle workStatus on shifts
+        if (isCKeyRecent() && calEvent.entityType === CalendarEntityType.SHIFT) {
+            if (!strategy.actions.canCompleteEvent?.(calEvent)) {
+                addAlert('warning', 'You do not have permission to change work status');
+                return;
+            }
+            if (calEvent.isRecurringInstance) {
+                addAlert('warning', 'Open the event to change work status for a recurring instance');
+                return;
+            }
+            const newStatus = calEvent.workStatus === 'completed' ? 'notCompleted' : 'completed';
+            setCalendarShifts(prev =>
+                prev.map(e => e.id === calEvent.id ? { ...e, workStatus: newStatus } : e)
+            );
+            try {
+                await updateWorkStatusInFirestore(calEvent.id, newStatus);
+                addAlert('success', newStatus === 'completed' ? 'Marked as completed' : 'Marked as not completed');
+            } catch (error) {
+                setCalendarShifts(prev =>
+                    prev.map(e => e.id === calEvent.id ? { ...e, workStatus: calEvent.workStatus } : e)
+                );
+                addAlert('error', `Failed to update: ${error.message}`);
+            }
+            return;
+        }
+
         const action = strategy.actions.getEventFlow(calEvent);
         if (!action) return;
 

--- a/src/lib/patterns/calendarStrategy.js
+++ b/src/lib/patterns/calendarStrategy.js
@@ -70,6 +70,7 @@ export const adminCalendarStrategy = () => ({
         canCreateEvent: (event) => event.entityType === CalendarEntityType.SHIFT,
         canModifyEvent: (event) => event.entityType === CalendarEntityType.SHIFT,
         canDuplicateEvent: (event) => event.entityType === CalendarEntityType.SHIFT,
+        canCompleteEvent: (event) => event.entityType === CalendarEntityType.SHIFT,
 
         // should only be allowed to create / edit shifts
         getCreateFlow: () => CalendarFlow.CREATE_SHIFT,
@@ -119,6 +120,7 @@ export const teacherCalendarStrategy = () => ({
         canCreateEvent:    (event) => event.entityType === CalendarEntityType.STUDENT_REQUEST,
         canModifyEvent:    (event) => event.entityType === CalendarEntityType.STUDENT_REQUEST,
         canDuplicateEvent: (event) => event.entityType === CalendarEntityType.STUDENT_REQUEST,
+        canCompleteEvent: () => false,
 
         getCreateFlow: () => CalendarFlow.CREATE_STUDENT_REQUEST,
         getEventFlow: (event) => {
@@ -174,6 +176,7 @@ export const tutorCalendarStrategy = (userEmail) => ({
         canCreateEvent: (event) => event.entityType === CalendarEntityType.AVAILABILITY,
         canModifyEvent: (event) => event.entityType === CalendarEntityType.AVAILABILITY,
         canDuplicateEvent: (event) => event.entityType === CalendarEntityType.AVAILABILITY,
+        canCompleteEvent: (event) => event.entityType === CalendarEntityType.SHIFT,
 
         getCreateFlow: () => CalendarFlow.CREATE_AVAILABILITY,
         getEventFlow: (event) => {
@@ -251,6 +254,7 @@ export const studentCalendarStrategy = (userEmail) => ({
                 return false
             }
         },
+        canCompleteEvent: () => false,
 
         getCreateFlow: () => CalendarFlow.CREATE_STUDENT_REQUEST,
         getEventFlow: (calEvent) => {


### PR DESCRIPTION
## Summary

Adds a keyboard shortcut to quickly mark shifts as completed or not completed directly from the calendar — hold the **C** key and click a shift event to toggle its `workStatus`.

## Changes

### `src/lib/patterns/calendarStrategy.js`
- Added `canCompleteEvent` permission to all four calendar strategies:
  - **Admin**: can complete shifts ✅
  - **Tutor**: can complete shifts ✅
  - **Teacher**: cannot complete ❌
  - **Student**: cannot complete ❌

### `src/components/calendar/CalendarContent.jsx`
- Added `updateWorkStatusInFirestore` import
- Added a lightweight `useEffect` + `useRef` to track when the bare `C` key is pressed (600ms window, ignores form elements)
- Added C+click logic at the top of `handleSelectEvent`:
  - Checks `canCompleteEvent` permission
  - Guards against recurring instances (user should open the event instead)
  - Optimistically toggles `workStatus` in local state
  - Persists to Firestore with automatic rollback on failure

## How to test
1. Open the calendar as an admin or tutor
2. Hold the **C** key and click on a shift event
3. The shift should toggle between `completed` and `notCompleted` with a success toast
4. Verify teachers and students see a warning toast if they attempt the shortcut