### PR TITLE
Fix availability duplication payloads

### DIFF
--- a/src/components/calendar/CalendarContent.jsx
+++ b/src/components/calendar/CalendarContent.jsx
@@ -268,7 +268,19 @@ const CalendarContent = () => {
             if (blockIfTutorConflict(event, newStart, newEnd)) return;
 
             // copy event data but remove properties that shouldn't be duplicated and create duplication event dictionary
-            const { id, createdAt, updatedAt, recurringEventId, isRecurringInstance, recurring, until, eventExceptions, entityType, ...eventData } = event;
+            const {
+                id,
+                createdAt,
+                updatedAt,
+                recurringEventId,
+                isRecurringInstance,
+                recurring,
+                until,
+                eventExceptions,
+                entityType,
+                originalAvailabilityId,
+                ...eventData
+            } = event;
             const duplicatedEvent = {
                 ...eventData,
                 start: newStart,

--- a/src/firestore/firestoreOperations.js
+++ b/src/firestore/firestoreOperations.js
@@ -1,5 +1,40 @@
 import { doc, updateDoc, addDoc, deleteDoc, getDoc, collection, setDoc, arrayUnion } from 'firebase/firestore';
 import { db } from '@/firestore/firestoreClient';
+
+const isPlainObject = (value) => {
+    if (value === null || Object.prototype.toString.call(value) !== '[object Object]') {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+};
+
+export const stripUndefinedFields = (value) => {
+    if (value === undefined) {
+        return undefined;
+    }
+
+    if (Array.isArray(value)) {
+        return value
+            .map(stripUndefinedFields)
+            .filter((item) => item !== undefined);
+    }
+
+    if (!isPlainObject(value)) {
+        return value;
+    }
+
+    const cleaned = {};
+    for (const [key, fieldValue] of Object.entries(value)) {
+        const cleanedValue = stripUndefinedFields(fieldValue);
+        if (cleanedValue !== undefined) {
+            cleaned[key] = cleanedValue;
+        }
+    }
+
+    return cleaned;
+};
 /**
  * Queue an email notification for a shift allocation or time change.
  * Uses shiftId as doc ID so rapid edits collapse into one notification.
@@ -102,17 +137,18 @@ export const updateWorkStatusInFirestore = async (shiftId, workStatus) => {
  */
 export const updateEventInFirestore = async (eventId, eventData, collectionName = 'shifts') => {
     const eventDoc = doc(db, collectionName, eventId);
+    const firestoreData = { ...eventData };
 
     // Rebuild emailsList if staff or students are being updated
-    if (eventData.staff !== undefined || eventData.students !== undefined) {
-        const staffEmails = (eventData.staff || []).map(s => typeof s === 'object' ? s.value : s);
-        const studentEmails = (eventData.students || []).map(s => typeof s === 'object' ? s.value : s);
-        eventData.staffEmails = staffEmails;
-        eventData.studentEmails = studentEmails;
-        eventData.emailsList = [...new Set([...staffEmails, ...studentEmails])];
+    if (firestoreData.staff !== undefined || firestoreData.students !== undefined) {
+        const staffEmails = (firestoreData.staff || []).map(s => typeof s === 'object' ? s.value : s);
+        const studentEmails = (firestoreData.students || []).map(s => typeof s === 'object' ? s.value : s);
+        firestoreData.staffEmails = staffEmails;
+        firestoreData.studentEmails = studentEmails;
+        firestoreData.emailsList = [...new Set([...staffEmails, ...studentEmails])];
     }
 
-    await updateDoc(eventDoc, eventData);
+    await updateDoc(eventDoc, stripUndefinedFields(firestoreData));
 };
 
 /**
@@ -126,12 +162,12 @@ export const createEventInFirestore = async (eventData, collectionName = 'shifts
     const studentEmails = (eventData.students || []).map(s => typeof s === 'object' ? s.value : s);
     const emailsList = [...new Set([...staffEmails, ...studentEmails])];
 
-    const docRef = await addDoc(collection(db, collectionName), {
+    const docRef = await addDoc(collection(db, collectionName), stripUndefinedFields({
         ...eventData,
         staffEmails,
         studentEmails,
         emailsList,
-    });
+    }));
     return docRef.id;
 };
 

--- a/src/utils/calendarAvailability.js
+++ b/src/utils/calendarAvailability.js
@@ -103,13 +103,18 @@ export const calendarAvailabilitySplit = (availabilities, events) => {
 
         // Add remaining slot
         if (slotStart < currentEnd) {
-            splitSlots.push({
+            const remainingSlot = {
                 ...availability,
                 id: wasSplit ? crypto.randomUUID() : availability.id,
-                originalAvailabilityId: wasSplit ? availability.id : undefined,
                 start: slotStart,
                 end: currentEnd,
-            });
+            };
+
+            if (wasSplit) {
+                remainingSlot.originalAvailabilityId = availability.id;
+            }
+
+            splitSlots.push(remainingSlot);
         }
     }
 

--- a/src/utils/calendarEvent.js
+++ b/src/utils/calendarEvent.js
@@ -852,8 +852,9 @@ export const calendarEventHandleDuplicate = async (
 
     // Handle tutor availability duplication — Firestore ensures only own availabilities are received
     if (event.tutor && userRole === 'tutor') {
+        const { id, entityType, originalAvailabilityId, ...eventData } = event;
         const availabilityData = {
-            ...event,
+            ...eventData,
             start: nextDayStart,
             end: nextDayEnd,
         };

--- a/tests/unit/calendarAvailability.test.js
+++ b/tests/unit/calendarAvailability.test.js
@@ -130,7 +130,7 @@ describe('calendarAvailabilitySplit', () => {
 
         expect(result).toHaveLength(1);
         expect(result[0].id).toBe('real-doc-id');
-        expect(result[0].originalAvailabilityId).toBeUndefined();
+        expect(result[0]).not.toHaveProperty('originalAvailabilityId');
     });
 
     test('split fragments carry originalAvailabilityId pointing at the real doc', () => {

--- a/tests/unit/firestoreOperations.test.js
+++ b/tests/unit/firestoreOperations.test.js
@@ -1,0 +1,65 @@
+import { addDoc } from 'firebase/firestore';
+import {
+    createEventInFirestore,
+    stripUndefinedFields,
+} from '@/firestore/firestoreOperations';
+
+describe('stripUndefinedFields', () => {
+    test('removes undefined values from Firestore payloads without removing nulls', () => {
+        const start = new Date('2026-06-11T10:00:00');
+
+        const cleaned = stripUndefinedFields({
+            title: 'Availability',
+            start,
+            originalAvailabilityId: undefined,
+            locationType: null,
+            staff: [
+                { value: 'tutor@example.edu', label: undefined },
+                undefined,
+            ],
+            metadata: {
+                keep: true,
+                drop: undefined,
+            },
+        });
+
+        expect(cleaned).not.toHaveProperty('originalAvailabilityId');
+        expect(cleaned.locationType).toBeNull();
+        expect(cleaned.start).toBe(start);
+        expect(cleaned.staff).toEqual([{ value: 'tutor@example.edu' }]);
+        expect(cleaned.metadata).toEqual({ keep: true });
+    });
+});
+
+describe('createEventInFirestore', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        addDoc.mockResolvedValue({ id: 'created-doc-id' });
+    });
+
+    test('strips undefined duplicate metadata before creating availability docs', async () => {
+        const docId = await createEventInFirestore(
+            {
+                title: 'Availability',
+                tutor: 'tutor@example.edu',
+                start: new Date('2026-06-11T10:00:00'),
+                end: new Date('2026-06-11T15:00:00'),
+                originalAvailabilityId: undefined,
+                metadata: {
+                    keep: 'yes',
+                    drop: undefined,
+                },
+            },
+            'tutorAvailabilities',
+        );
+
+        expect(docId).toBe('created-doc-id');
+
+        const payload = addDoc.mock.calls[0][1];
+        expect(payload).not.toHaveProperty('originalAvailabilityId');
+        expect(payload.metadata).toEqual({ keep: 'yes' });
+        expect(payload.staffEmails).toEqual([]);
+        expect(payload.studentEmails).toEqual([]);
+        expect(payload.emailsList).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- stop unsplit availability render events from carrying `originalAvailabilityId: undefined`
- omit render-only availability metadata when duplicating events
- strip undefined fields before Firestore create/update writes
- add regression coverage for availability split output and Firestore payload cleanup

## Tests
- `npm test -- --runTestsByPath tests/unit/calendarAvailability.test.js tests/unit/firestoreOperations.test.js`
- `npm test`
- `npm run lint`